### PR TITLE
Added camera support, part one

### DIFF
--- a/config/rq_camera.yaml
+++ b/config/rq_camera.yaml
@@ -1,0 +1,8 @@
+/**:
+  ros__parameters:
+    name: "camera_node"
+    framerate: 3.0
+    video_device: /dev/video0
+    brightness: 128
+    contrast: 128
+    saturation: 128

--- a/launch/roboquest_core.launch.py
+++ b/launch/roboquest_core.launch.py
@@ -4,17 +4,22 @@ from launch import LaunchDescription
 from launch_ros.actions import Node
 
 def generate_launch_description():
-    params = os.path.join(
+    base_params = os.path.join(
         get_package_share_directory('roboquest_core'),
         'config',
         'roboquest_base.yaml'
+    )
+    camera_params = os.path.join(
+        get_package_share_directory('roboquest_core'),
+        'config',
+        'rq_camera.yaml'
     )
 
     rq_base_node = Node(
         name='rq_base_node',
         package="roboquest_core",
         executable="roboquest_base_node.py",
-        parameters=[params],
+        parameters=[base_params],
         respawn=True,
         respawn_delay=5
     )
@@ -23,6 +28,7 @@ def generate_launch_description():
         name='rq_camera_node',
         package="usb_cam",
         executable="usb_cam_node_exe",
+        parameters=[camera_params],
         respawn=True,
         respawn_delay=5
     )

--- a/launch/roboquest_core.launch.py
+++ b/launch/roboquest_core.launch.py
@@ -12,12 +12,18 @@ def generate_launch_description():
         'roboquest_base.yaml'
     )
 
-    roboquest_base_node = Node(
+    rq_base_node = Node(
         package="roboquest_core",
         executable="roboquest_base_node.py",
         parameters=[base_config]
     )
 
-    ld.add_action(roboquest_base_node)
+    rq_camera_node = Node(
+        package="usb_cam",
+        executable="usb_cam_node_exe"
+    )
+
+    ld.add_action(rq_base_node)
+    ld.add_action(rq_camera_node)
 
     return ld

--- a/launch/roboquest_core.launch.py
+++ b/launch/roboquest_core.launch.py
@@ -4,26 +4,29 @@ from launch import LaunchDescription
 from launch_ros.actions import Node
 
 def generate_launch_description():
-    ld = LaunchDescription()
-
-    base_config = os.path.join(
+    params = os.path.join(
         get_package_share_directory('roboquest_core'),
         'config',
         'roboquest_base.yaml'
     )
 
     rq_base_node = Node(
+        name='rq_base_node',
         package="roboquest_core",
         executable="roboquest_base_node.py",
-        parameters=[base_config]
+        parameters=[params],
+        respawn=True,
+        respawn_delay=5
     )
 
     rq_camera_node = Node(
+        name='rq_camera_node',
         package="usb_cam",
-        executable="usb_cam_node_exe"
+        executable="usb_cam_node_exe",
+        respawn=True,
+        respawn_delay=5
     )
 
-    ld.add_action(rq_base_node)
-    ld.add_action(rq_camera_node)
-
-    return ld
+    return LaunchDescription([rq_base_node,
+                              rq_camera_node
+                             ])


### PR DESCRIPTION
Added functionality to retrieve frames from a color web cam and push them through the web socket to the browser.

Requires [roboquest PR 8](https://github.com/billmania/roboquest/pull/8) and [roboquest_ui PR 5](https://github.com/billmania/roboquest_ui/pull/5).

Tested by deploying both containers to the Rasp Pi 4B and then pointing a browser at http://rasppi4b:3456/rq_index.html.