### PR TITLE
Added RQMotors class to control drive motors

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>roboquest_core</name>
-  <version>0.0.2</version>
+  <version>0.0.3</version>
   <description>ROS2 package for the RoboQuest backend</description>
   <maintainer email="bill@manialabs.us">Bill Mania</maintainer>
   <license>Proprietary</license>
@@ -18,6 +18,7 @@
 
   <depend>rclpy</depend>
   <depend>std_msgs</depend>
+  <depend>geometry_msgs</depend>
   <depend>rq_msgs</depend>
   <depend>diagnostic_msgs</depend>
 

--- a/roboquest_core/rq_motors.py
+++ b/roboquest_core/rq_motors.py
@@ -40,7 +40,7 @@ class RQMotors(object):
 
         self._write_errors = 0
 
-        self._motor_max_speed = 0
+        self._motor_max_speed = 100
         self._motors_enabled = False
 
         self._setup_gpio()
@@ -121,7 +121,7 @@ class RQMotors(object):
         """
 
         if not self._motors_enabled:
-            return
+            return False
 
         tries = 3
         while tries:

--- a/roboquest_core/rq_motors.py
+++ b/roboquest_core/rq_motors.py
@@ -1,0 +1,151 @@
+from struct import pack
+from time import sleep
+
+import smbus2
+
+import RPi.GPIO as GPIO
+
+MOTOR_ENABLE_PIN = 17
+#
+# BUS ID 6 doesn't appear on the RaspPi
+#
+I2C_BUS_ID = 1
+I2C_DEVICE_ID = 0x53
+
+I2C_MOTOR_RIGHT_REGISTER = 3
+I2C_MOTOR_LEFT_REGISTER = 4
+
+WRITE_ERROR_WAIT_S = 0.01
+
+
+class RQMotors(object):
+    """
+    Manages the operation of the two drive motors connected to the I2C
+    bus.
+
+    pub_motorPwrState = rospy.Publisher(
+        'motor_controller_power_enable_state',
+        Bool,
+        queue_size = 1,
+        latch = True)
+    rospy.Subscriber("drive_joystick",Vector3, callback_drivejs)
+    rospy.Subscriber("motor_controller_power_enable",Bool, callback_enable)
+    rospy.Subscriber("motor_controller_max_speed",Float64, callback_speed)
+    """
+
+    def __init__(self):
+        """
+        Configure the motor control sub-system for use.
+        """
+
+        self._write_errors = 0
+
+        self._motor_max_speed = 0
+        self._motors_enabled = False
+
+        self._setup_gpio()
+        self._setup_i2c()
+
+    def set_motor_max_speed(self, max_speed: int) -> None:
+        """
+        Set the maximum speed of the motors as a positive percentage.
+        """
+
+        self._motor_max_speed = max_speed
+
+    def _setup_gpio(self) -> None:
+        """
+        Initialize the GPIO subsystem.
+        """
+
+        GPIO.setmode(GPIO.BCM)
+        GPIO.setup(MOTOR_ENABLE_PIN, GPIO.OUT)
+        GPIO.output(MOTOR_ENABLE_PIN, GPIO.LOW)
+
+    def _setup_i2c(self) -> None:
+        """
+        Initialize the I2C bus.
+        """
+
+        self._bus = smbus2.SMBus(I2C_BUS_ID)
+
+    def motors_are_enabled(self) -> bool:
+        """
+        Returns True when the motors are enabled.
+        """
+
+        return self._motors_enabled
+
+    def enable_motors(self, enable: bool = False) -> None:
+        """
+        Enable or disable the motors.
+        """
+
+        if (enable and not self._motors_enabled):
+            GPIO.output(MOTOR_ENABLE_PIN, GPIO.HIGH)
+            sleep(0.2)
+            self._motors_enabled = True
+
+        if (not enable and self._motors_enabled):
+            GPIO.output(MOTOR_ENABLE_PIN, GPIO.LOW)
+            self._motors_enabled = False
+
+    def _pack_speed(self, speed: int) -> bytes:
+        """
+        Pack a 4 byte signed integer into 4 bytes, little-endian.
+        """
+
+        return pack('<i', speed)
+
+    def _constrain_speed(self, speed: int) -> int:
+        """
+        Constrain speed to be in
+        [-self._motor_max_speed, self._motor_max_speed], clipping speed
+        if it is not.
+        """
+
+        return max(min(int(speed),
+                       self._motor_max_speed),
+                   -self._motor_max_speed)
+
+    def set_motors_velocity(self, right: int = 0, left: int = 0) -> bool:
+        """
+        An open loop control for the velocity of each drive motor.
+        right and left are the percentage of full power to apply
+        to each motor. A positive percentage indicates the forward
+        rotation. Values outside the range [-100, 100] will be
+        clipped.
+
+        The velocity of the right motor is always set first, which
+        will likely have an impact on the robot's motion.
+        """
+
+        if not self._motors_enabled:
+            return
+
+        tries = 3
+        while tries:
+            tries -= 1
+
+            try:
+                self._bus.write_i2c_block_data(
+                    I2C_DEVICE_ID,
+                    I2C_MOTOR_RIGHT_REGISTER,
+                    list(self._pack_speed(self._constrain_speed(right)))
+                )
+                self._bus.write_i2c_block_data(
+                    I2C_DEVICE_ID,
+                    I2C_MOTOR_LEFT_REGISTER,
+                    list(self._pack_speed(self._constrain_speed(left)))
+                )
+
+                return True
+
+            except Exception:
+                # TODO: What are the possible Exceptions?
+                self._write_errors += 1
+                sleep(WRITE_ERROR_WAIT_S)
+
+        self.enable_motors(False)
+
+        return False


### PR DESCRIPTION
The RQMotors class was integrated with the roboquest_base_node via the RQManage class. It handles communication with the I2C bus, setting max speed, setting individual motor velocity, and clipping the velocities. Although it has logic to enable and disable the motors by controlling a GPIO pin, that doesn't actually stop the motors with the HAT firmware v5.1.

The velocity input commands are packaged as Twist messages. The current mapping from linear.x and angular.z is a brute-force, inappropriate function.

Tested with RaspPi4B and HAT firmware v5.1, with the node running in a docker container on the RaspPi4B and using rqt to call the Control service and publish Twist messages.

Requires [roboquest PR 9](https://github.com/billmania/roboquest/pull/9) and [rq_msgs PR 1](https://github.com/billmania/rq_msgs/pull/1)