### PR TITLE
Added Servo control

### DIFF
--- a/roboquest_core/rq_motors.py
+++ b/roboquest_core/rq_motors.py
@@ -6,10 +6,7 @@ import smbus2
 import RPi.GPIO as GPIO
 
 MOTOR_ENABLE_PIN = 17
-#
-# BUS ID 6 doesn't appear on the RaspPi
-#
-I2C_BUS_ID = 1
+I2C_BUS_ID = 6
 I2C_DEVICE_ID = 0x53
 
 I2C_MOTOR_RIGHT_REGISTER = 3
@@ -22,15 +19,6 @@ class RQMotors(object):
     """
     Manages the operation of the two drive motors connected to the I2C
     bus.
-
-    pub_motorPwrState = rospy.Publisher(
-        'motor_controller_power_enable_state',
-        Bool,
-        queue_size = 1,
-        latch = True)
-    rospy.Subscriber("drive_joystick",Vector3, callback_drivejs)
-    rospy.Subscriber("motor_controller_power_enable",Bool, callback_enable)
-    rospy.Subscriber("motor_controller_max_speed",Float64, callback_speed)
     """
 
     def __init__(self):

--- a/roboquest_core/rq_servos.py
+++ b/roboquest_core/rq_servos.py
@@ -1,0 +1,206 @@
+from time import sleep
+
+import smbus2
+
+import RPi.GPIO as GPIO
+from rq_servos_config import SERVO_QTY, servo_config
+
+SERVO_ENABLE_PIN = 23
+I2C_BUS_ID = 1
+#
+# There's an unknown device at 0x70 on bus 1.
+#
+I2C_DEVICE_ID = 0x40
+
+WRITE_ERROR_WAIT_S = 0.01
+
+#
+# PCA9685 registers
+#
+# TODO: Convert to an Enum or ROS parameters
+MODE1_REG = 0x00
+MODE2_REG = 0x01
+PRESCALE_REG = 0xfe
+#
+# The registers, low and high byte, controlling the Pulse Width.
+#
+PULSE0_ON_L_REG = 0x06
+PULSE0_ON_H_REG = 0x07
+PULSE0_OFF_L_REG = 0x08
+PULSE0_OFF_H_REG = 0x09
+
+
+#
+# PCA9685 constants
+#
+# TODO: Convert to an Enum or ROS parameters
+OUTDRV_VALUE = 0x04  # totem pole outputs
+PRESCALE_VALUE = 0x79
+MODE1_VALUE = 0x00
+
+SETUPS = [(MODE2_REG, OUTDRV_VALUE),
+          (PRESCALE_REG, PRESCALE_VALUE),
+          (MODE1_REG, MODE1_VALUE)]
+
+
+class RQServos(object):
+    """
+    Manages the operation of the PCA9685 controller connected to the I2C
+    bus.
+    """
+
+    def __init__(self):
+        """
+        Setup communication with the servo sub-system. The PCA9685 I2C
+        servo controller isn't configured until it's powered and then
+        each time the power is cycled.
+        """
+
+        self._write_errors = 0
+
+        self._servos, self._servos_state = servo_config()
+        self._controller_powered = False
+
+        self._setup_gpio()
+        self._setup_i2c()
+
+    def _setup_gpio(self) -> None:
+        """
+        Initialize the GPIO subsystem.
+        """
+
+        GPIO.setmode(GPIO.BCM)
+        GPIO.setup(SERVO_ENABLE_PIN, GPIO.OUT)
+        GPIO.output(SERVO_ENABLE_PIN, GPIO.LOW)
+
+    def _setup_i2c(self) -> None:
+        """
+        Initialize the I2C bus.
+        """
+
+        self._bus = smbus2.SMBus(I2C_BUS_ID)
+
+    def _translate(self, value, in_min, in_max, out_min, out_max) -> int:
+        """
+        Translate value somehow. The original implementation of this method
+        was named 'map' which is an existing Python builtin function.
+        """
+
+        return ((value - in_min) * (out_max - out_min)
+                / (in_max - in_min) + out_min)
+
+    def _set_servo_pwm(self, id: int, on: int, off: int) -> None:
+        """
+        Command the servo with a specific PWM signal, which was calculated
+        based on a desired angle.
+        """
+
+        self._bus.write_byte_data(I2C_DEVICE_ID,
+                                  PULSE0_ON_L_REG+4*id,
+                                  on & 0xFF)
+        self._bus.write_byte_data(I2C_DEVICE_ID,
+                                  PULSE0_ON_H_REG+4*id,
+                                  on >> 8)
+        self._bus.write_byte_data(I2C_DEVICE_ID,
+                                  PULSE0_OFF_L_REG+4*id,
+                                  off & 0xFF)
+        self._bus.write_byte_data(I2C_DEVICE_ID,
+                                  PULSE0_OFF_H_REG+4*id,
+                                  off >> 8)
+
+    def set_servo_angle(self, id: int, angle: int = None) -> None:
+        """
+        For servo id set its angle.
+        """
+
+        if angle is None:
+            angle = self._servos_state[id]['angle']
+
+        if self._controller_powered and self._servos_state[id]['enabled']:
+            angle = self._constrain(0, angle, self._servos[id].angle_max_deg)
+            self._servos_state[id]['angle'] = angle
+
+            off_pulse = self._translate(angle,
+                                        0,
+                                        self._servos[id].angle_max_deg,
+                                        self._servos[id].pulse_min,
+                                        self._servos[id].pulse_max)
+            off_count = self._constrain(0,
+                                        int(self._translate(off_pulse,
+                                                            0,
+                                                            20000,
+                                                            0,
+                                                            4095)),
+                                        4095)
+
+            on_count = 0
+            self._set_servo_pwm(id, on_count, off_count)
+
+    def _pca9685_init(self):
+        """
+        Configure the PCA9685 for use, usually each time power is applied.
+
+        MODE1 to wake
+        MODE2 to totem pole
+        PRESCALE to 50 Hz
+
+        Set the initial angle of each servo according to the configuration
+        parameters.
+        """
+
+        for register, value in SETUPS:
+            self._bus.write_byte_data(I2C_DEVICE_ID, register, value)
+            sleep(0.05)
+
+        for id in range(SERVO_QTY):
+            self._servos_state[id]['enabled'] = True
+            self.set_servo_angle(id, self._servos[id].angle_init_deg)
+            sleep(self._servos[id].init_delay_s)
+
+    def servos_are_enabled(self) -> bool:
+        """
+        Returns True when the servos are enabled.
+        """
+
+        return self._controller_powered
+
+    def disable_servo(self, id: int) -> None:
+        """
+        Flat-line the PWM signal to the servo and prevent a new angle
+        from being set by set_servo_angle(). The effect of this method
+        is undone by restore_servo_angle().
+        """
+
+        self._servos_state[id]['enabled'] = False
+        self._set_servo_pwm(id, 0, 0)
+
+    def restore_servo_angle(self, id: int) -> None:
+        """
+        Set the servo to its most recent angle, to recover from the
+        PWM signal having been flat-lined by disable_servo().
+        """
+
+        self._servos_state[id]['enabled'] = True
+        self.set_servo_angle(id)
+
+    def set_power(self, enable: bool = False) -> None:
+        """
+        Enable or disable power to the servo controller.
+        """
+
+        if (enable and not self._controller_powered):
+            GPIO.output(SERVO_ENABLE_PIN, GPIO.HIGH)
+            sleep(0.5)
+            self._controller_powered = True
+            self._pca9685_init()
+
+        if (not enable and self._controller_powered):
+            GPIO.output(SERVO_ENABLE_PIN, GPIO.LOW)
+            self._controller_powered = False
+
+    def _constrain(self, min_value: int, value: int, max_value: int) -> int:
+        """
+        Clip value to be between min and max, inclusive.
+        """
+
+        return max(min(value, max_value), min_value)

--- a/roboquest_core/rq_servos.py
+++ b/roboquest_core/rq_servos.py
@@ -8,9 +8,6 @@ from roboquest_core.rq_servos_config import servo_config
 
 SERVO_ENABLE_PIN = 23
 I2C_BUS_ID = 1
-#
-# There's an unknown device at 0x70 on bus 1.
-#
 I2C_DEVICE_ID = 0x40
 
 WRITE_ERROR_WAIT_S = 0.01

--- a/roboquest_core/rq_servos_config.py
+++ b/roboquest_core/rq_servos_config.py
@@ -4,8 +4,10 @@ from collections import namedtuple
 SERVO_QTY = 16
 
 Servo = namedtuple('Servo',
-                   ['id',
+                   ['channel',
+                    'name',
                     'init_delay_s',
+                    'angle_min_deg',
                     'angle_max_deg',
                     'angle_init_deg',
                     'pulse_min',
@@ -13,7 +15,9 @@ Servo = namedtuple('Servo',
                     ],
                    defaults=[
                        SERVO_QTY,
+                       'undefined',
                        0.05,
+                       0,
                        180,
                        90,
                        600,
@@ -21,80 +25,63 @@ Servo = namedtuple('Servo',
                    ])
 
 
-def servo_config() -> (List[Servo], List[dict]):
+def servo_config() -> (List[Servo], dict, List[dict]):
     """
-    Return two lists:
-        - Servo named tuples, each of which describes a servo.
-        - dictionary with two attributes: enabled and angle;
+    Return three objects:
+        - a list of Servo named tuples, each of which describes a servo.
+        - a dictionary mapping servo names to the Servo named tuples
+        - a list of dictionaries with two attributes: enabled and angle;
 
-    Each list contains SERVO_QTY instances, in servo ID order.
+    All three objects contain SERVO_QTY instances. The two lists are
+    in servo channel order so they can be indexed by channel.
     """
 
     servo_list = list()
+    name_map = dict()
     servo_state_list = list()
-    servo_list.append(Servo(id=0, init_delay_s=0))
-    servo_state_list.append(
-        {'enabled': False,
-         'angle': servo_list[len(servo_list)-1].angle_init_deg})
-    servo_list.append(Servo(id=1, init_delay_s=1, pulse_max=2500))
-    servo_state_list.append(
-        {'enabled': False,
-         'angle': servo_list[len(servo_list)-1].angle_init_deg})
-    servo_list.append(Servo(id=2, init_delay_s=0.3))
-    servo_state_list.append(
-        {'enabled': False,
-         'angle': servo_list[len(servo_list)-1].angle_init_deg})
-    servo_list.append(Servo(id=3))
-    servo_state_list.append(
-        {'enabled': False,
-         'angle': servo_list[len(servo_list)-1].angle_init_deg})
-    servo_list.append(Servo(id=4))
-    servo_state_list.append(
-        {'enabled': False,
-         'angle': servo_list[len(servo_list)-1].angle_init_deg})
-    servo_list.append(Servo(id=5))
-    servo_state_list.append(
-        {'enabled': False,
-         'angle': servo_list[len(servo_list)-1].angle_init_deg})
-    servo_list.append(Servo(id=6))
-    servo_state_list.append(
-        {'enabled': False,
-         'angle': servo_list[len(servo_list)-1].angle_init_deg})
-    servo_list.append(Servo(id=7))
-    servo_state_list.append(
-        {'enabled': False,
-         'angle': servo_list[len(servo_list)-1].angle_init_deg})
-    servo_list.append(Servo(id=8))
-    servo_state_list.append(
-        {'enabled': False,
-         'angle': servo_list[len(servo_list)-1].angle_init_deg})
-    servo_list.append(Servo(id=9))
-    servo_state_list.append(
-        {'enabled': False,
-         'angle': servo_list[len(servo_list)-1].angle_init_deg})
-    servo_list.append(Servo(id=10))
-    servo_state_list.append(
-        {'enabled': False,
-         'angle': servo_list[len(servo_list)-1].angle_init_deg})
-    servo_list.append(Servo(id=11))
-    servo_state_list.append(
-        {'enabled': False,
-         'angle': servo_list[len(servo_list)-1].angle_init_deg})
-    servo_list.append(Servo(id=12))
-    servo_state_list.append(
-        {'enabled': False,
-         'angle': servo_list[len(servo_list)-1].angle_init_deg})
-    servo_list.append(Servo(id=13))
-    servo_state_list.append(
-        {'enabled': False,
-         'angle': servo_list[len(servo_list)-1].angle_init_deg})
-    servo_list.append(Servo(id=14))
-    servo_state_list.append(
-        {'enabled': False,
-         'angle': servo_list[len(servo_list)-1].angle_init_deg})
-    servo_list.append(Servo(id=15))
-    servo_state_list.append(
-        {'enabled': False,
-         'angle': servo_list[len(servo_list)-1].angle_init_deg})
+    servo_list.append(Servo(channel=0,
+                            name='camera_pan',
+                            init_delay_s=0))
+    servo_list.append(Servo(channel=1,
+                            name='camera_tilt',
+                            init_delay_s=1,
+                            angle_min_deg=50,
+                            pulse_max=2500))
+    servo_list.append(Servo(channel=2,
+                            name='shoulder_pan',
+                            init_delay_s=0.3))
+    servo_list.append(Servo(channel=3,
+                            name='shoulder_tilt',
+                            angle_init_deg=40,
+                            angle_max_deg=115))
+    servo_list.append(Servo(channel=4,
+                            name='elbow',
+                            angle_max_deg=60,
+                            angle_min_deg=5,
+                            angle_init_deg=5))
+    servo_list.append(Servo(channel=5,
+                            name='wrist_pan',
+                            angle_init_deg=60))
+    servo_list.append(Servo(channel=6,
+                            name='wrist_tilt'))
+    servo_list.append(Servo(channel=7,
+                            name='gripper_pan'))
+    servo_list.append(Servo(channel=8,
+                            name='gripper',
+                            angle_max_deg=75,
+                            angle_init_deg=0))
+    servo_list.append(Servo(channel=9))
+    servo_list.append(Servo(channel=10))
+    servo_list.append(Servo(channel=11))
+    servo_list.append(Servo(channel=12))
+    servo_list.append(Servo(channel=13))
+    servo_list.append(Servo(channel=14))
+    servo_list.append(Servo(channel=15))
 
-    return servo_list, servo_state_list
+    for servo in servo_list:
+        name_map[servo.name] = servo
+        servo_state_list.append(
+            {'enabled': False,
+             'angle': servo.angle_init_deg})
+
+    return servo_list, name_map, servo_state_list

--- a/roboquest_core/rq_servos_config.py
+++ b/roboquest_core/rq_servos_config.py
@@ -1,0 +1,100 @@
+from typing import List
+from collections import namedtuple
+
+SERVO_QTY = 16
+
+Servo = namedtuple('Servo',
+                   ['id',
+                    'init_delay_s',
+                    'angle_max_deg',
+                    'angle_init_deg',
+                    'pulse_min',
+                    'pulse_max'
+                    ],
+                   defaults=[
+                       SERVO_QTY,
+                       0.05,
+                       180,
+                       90,
+                       600,
+                       2400
+                   ])
+
+
+def servo_config() -> (List[Servo], List[dict]):
+    """
+    Return two lists:
+        - Servo named tuples, each of which describes a servo.
+        - dictionary with two attributes: enabled and angle;
+
+    Each list contains SERVO_QTY instances, in servo ID order.
+    """
+
+    servo_list = list()
+    servo_state_list = list()
+    servo_list.append(Servo(id=0, init_delay_s=0))
+    servo_state_list.append(
+        {'enabled': False,
+         'angle': servo_list[len(servo_list)-1].angle_init_deg})
+    servo_list.append(Servo(id=1, init_delay_s=1, pulse_max=2500))
+    servo_state_list.append(
+        {'enabled': False,
+         'angle': servo_list[len(servo_list)-1].angle_init_deg})
+    servo_list.append(Servo(id=2, init_delay_s=0.3))
+    servo_state_list.append(
+        {'enabled': False,
+         'angle': servo_list[len(servo_list)-1].angle_init_deg})
+    servo_list.append(Servo(id=3))
+    servo_state_list.append(
+        {'enabled': False,
+         'angle': servo_list[len(servo_list)-1].angle_init_deg})
+    servo_list.append(Servo(id=4))
+    servo_state_list.append(
+        {'enabled': False,
+         'angle': servo_list[len(servo_list)-1].angle_init_deg})
+    servo_list.append(Servo(id=5))
+    servo_state_list.append(
+        {'enabled': False,
+         'angle': servo_list[len(servo_list)-1].angle_init_deg})
+    servo_list.append(Servo(id=6))
+    servo_state_list.append(
+        {'enabled': False,
+         'angle': servo_list[len(servo_list)-1].angle_init_deg})
+    servo_list.append(Servo(id=7))
+    servo_state_list.append(
+        {'enabled': False,
+         'angle': servo_list[len(servo_list)-1].angle_init_deg})
+    servo_list.append(Servo(id=8))
+    servo_state_list.append(
+        {'enabled': False,
+         'angle': servo_list[len(servo_list)-1].angle_init_deg})
+    servo_list.append(Servo(id=9))
+    servo_state_list.append(
+        {'enabled': False,
+         'angle': servo_list[len(servo_list)-1].angle_init_deg})
+    servo_list.append(Servo(id=10))
+    servo_state_list.append(
+        {'enabled': False,
+         'angle': servo_list[len(servo_list)-1].angle_init_deg})
+    servo_list.append(Servo(id=11))
+    servo_state_list.append(
+        {'enabled': False,
+         'angle': servo_list[len(servo_list)-1].angle_init_deg})
+    servo_list.append(Servo(id=12))
+    servo_state_list.append(
+        {'enabled': False,
+         'angle': servo_list[len(servo_list)-1].angle_init_deg})
+    servo_list.append(Servo(id=13))
+    servo_state_list.append(
+        {'enabled': False,
+         'angle': servo_list[len(servo_list)-1].angle_init_deg})
+    servo_list.append(Servo(id=14))
+    servo_state_list.append(
+        {'enabled': False,
+         'angle': servo_list[len(servo_list)-1].angle_init_deg})
+    servo_list.append(Servo(id=15))
+    servo_state_list.append(
+        {'enabled': False,
+         'angle': servo_list[len(servo_list)-1].angle_init_deg})
+
+    return servo_list, servo_state_list


### PR DESCRIPTION
Implemented Servo functionality in the core base node. Added a minimum servo angle to the configuration and updated the configuration to match the current arm and camera mast. This is a completely open loop implementation without any control of servo speed or acceleration.

Tested with the motor controller, two drive motors, the servo controller, the arm, and the camera mast. Control power to both, spin the motors, wiggle the arm and the mast.

The service /control_hat manages the power. The topic /cmd_vel controls the motors. The topic /servos controls all of the servos. Mapping of Twist messages to motor control is very brute-force and inappropriate. Servos can be referenced by channel number and by name.

Requires [rq_msgs PR 2](https://github.com/billmania/rq_msgs/pull/2)