### PR TITLE
Use screen 4 as a place for status messages

### DIFF
--- a/roboquest_core/rq_manage.py
+++ b/roboquest_core/rq_manage.py
@@ -222,10 +222,13 @@ class RQManage(RQNode):
                             or button != HAT_BUTTON.NO_BUTTON):
                         self._hat.control_comms(enable=False)
 
-                        page_text = self._network.process_screen_request(
-                            screen, button)
-
-                        self._hat.write_sentence(page_text)
+                        if screen in [HAT_SCREEN.CONNECTIONS,
+                                      HAT_SCREEN.DEVICES]:
+                            page_text = self._network.process_screen_request(
+                                screen, button)
+                            self._hat.write_sentence(page_text)
+                        elif screen == HAT_SCREEN.STATUS:
+                            self._hat.show_status_msgs()
 
                         self._screen_sentences += 1
                         self._previous_screen = screen

--- a/roboquest_core/rq_network.py
+++ b/roboquest_core/rq_network.py
@@ -101,10 +101,8 @@ class RQNetwork(object):
             # This method was called for a SCREEN which doesn't involve
             # network connections.
             #
-            page_info += 'None'
+            page_info += ''
 
-        self._logger(
-            f"process_screen_request page_info {page_info}")
         return page_info
 
     def _get_all_connections(self) -> None:


### PR DESCRIPTION
The RQHAT class has two new methods: status_msg() and show_status_msgs(). The first adds a line of text to the collection of status messages. There is a configurable maximum number of status messages maintained in a FIFO buffer. The second method displays the buffer of status messages on the HAT OLED.
Status messages are displayed when the user manually selects screen 4 (which in HAT firmware v5.1 is named the "NET ETC" screen but will be renamed to "STATUS" in a future HAT firmware version).
When the RoboQuest software is started the message "HAT setup" is displayed. No other status messages have been defined.

The readability of the methods which manage the HAT OLED was improved and some minor inefficiencies in the values for several of the constants were corrected at the same time.