### PR TITLE
Enhancements to the software update mechanism

### DIFF
--- a/roboquest_core/rq_hat.py
+++ b/roboquest_core/rq_hat.py
@@ -3,6 +3,8 @@ from typing import Callable, Tuple
 import serial
 import RPi.GPIO as GPIO
 
+VERSION = 2
+
 READ_EOL = b'\r\n'
 READ_TIMEOUT_SEC = 0.2
 
@@ -131,6 +133,15 @@ class RQHAT(object):
         self._status_lines = list()
 
         self.status_msg('HAT setup')
+
+    def close(self):
+        """
+        Close the serial port and cleanup the GPIO. This method is not intended
+        for internal use.
+        """
+
+        self._hat.close()
+        GPIO.cleanup()
 
     def _open_hat_serial(self, port: str,
                          data_rate: int,

--- a/scripts/update_cli.bash
+++ b/scripts/update_cli.bash
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+#
+# Send the UPDATE command to the RoboQuest software updater.
+#
+
+VERSION=1
+UPDATE_FIFO="/tmp/update_fifo"
+COMMAND="{\"timestamp\": $(date +%s), \"version\": ${VERSION}, \"action\": \"UPDATE\", \"args\": \"\"}"
+
+if [[ -p "$UPDATE_FIFO" && -w "$UPDATE_FIFO" ]]
+then
+        printf "$COMMAND" > $UPDATE_FIFO
+        printf "UPDATE command sent\n"
+        exit 0
+fi
+
+printf "$UPDATE_FIFO does not exist as a writable named pipe\n" >&2
+printf "updater.py may not be running or you may not be superuser\n" >&2
+exit 1


### PR DESCRIPTION
Added update_cli.bash for testing updater.py and manually triggering a RoboQuest software update.

Added a close() to RQHAT() so updater.py could cleanly release /dev/gpiomem and /dev/ttyS0.

Updated updater.py to use RQHAT() and preserve the previous version of updater.py.

Tested on rasppi4b using update_cli.bash to manually trigger an update.