### PR TITLE
Set default motor control to ON

### DIFF
--- a/roboquest_core/rq_motors.py
+++ b/roboquest_core/rq_motors.py
@@ -27,9 +27,7 @@ class RQMotors(object):
         """
 
         self._write_errors = 0
-
         self._motor_max_speed = 100
-        self._motors_enabled = False
 
         self._setup_gpio()
         self._setup_i2c()
@@ -48,7 +46,9 @@ class RQMotors(object):
 
         GPIO.setmode(GPIO.BCM)
         GPIO.setup(MOTOR_ENABLE_PIN, GPIO.OUT)
-        GPIO.output(MOTOR_ENABLE_PIN, GPIO.LOW)
+        # TODO: Change the default to disabled
+        GPIO.output(MOTOR_ENABLE_PIN, GPIO.HIGH)
+        self._motors_enabled = True
 
     def _setup_i2c(self) -> None:
         """


### PR DESCRIPTION
Since there is not yet any support in the UI to enable and disable the motor control, the default was changed to ON.

Required for [roboquest_ui PR ]()