### PR TITLE
Updated rq_manage.py to populate the motors_on and servos_on

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>roboquest_core</name>
-  <version>0.0.3</version>
+  <version>0.1.0</version>
   <description>ROS2 package for the RoboQuest backend</description>
   <maintainer email="bill@manialabs.us">Bill Mania</maintainer>
   <license>Proprietary</license>

--- a/roboquest_core/rq_hat.py
+++ b/roboquest_core/rq_hat.py
@@ -274,8 +274,9 @@ $$SCREEN 1 0
 
     def charger_state(self) -> Tuple[bool, bool]:
         """
-        Return two booleans indicating if the battery is being charged and
-        if the charger is powered.
+        Return two booleans indicating if;
+            - the battery is being charged
+            - the charger has power
         """
 
         power_pin = GPIO.input(HAT_GPIO_PIN.CHARGER_POWERED.value)

--- a/roboquest_core/rq_manage.py
+++ b/roboquest_core/rq_manage.py
@@ -214,6 +214,8 @@ class RQManage(RQNode):
         telemetry_msg.adc4_v = float(fields[8])
         telemetry_msg.battery_charging, telemetry_msg.charger_has_power = \
             self._hat.charger_state()
+        telemetry_msg.motors_on = self._motors.motors_are_enabled()
+        telemetry_msg.servos_on = self._servos.controller_powered()
 
         self._telemetry_pub.publish(telemetry_msg)
 


### PR DESCRIPTION
Populates two new attributes in Telemetry interface, to support indicators in the UI. Minor doc-string improvement in rq_hat.py. Updated package.xml to version 0.1.0.

Tested by echoing /telemetry while calling service /control_hat and toggling set_motors, set_servos, and set_charger.

Requires [rq_msgs PR 3](https://github.com/billmania/rq_msgs/pull/3)