### PR TITLE
Converted to use the ArduCam instead of generic USB webcam

### DIFF
--- a/config/rq_camera.yaml
+++ b/config/rq_camera.yaml
@@ -1,8 +1,12 @@
 /**:
   ros__parameters:
-    name: "camera_node"
-    framerate: 3.0
-    video_device: /dev/video0
-    brightness: 128
-    contrast: 128
-    saturation: 128
+    height: 480
+    width: 640
+    role: still
+    qos_overrides:
+      /parameter_events:
+        publisher:
+          depth: 1
+          durability: volatile
+          history: keep_last
+          reliability: reliable

--- a/launch/roboquest_core.launch.py
+++ b/launch/roboquest_core.launch.py
@@ -24,14 +24,28 @@ def generate_launch_description():
         respawn_delay=5
     )
 
-    rq_camera_node = Node(
+    #
+    # For the ArduCam/RasPiCam
+    #
+    rq_camera_node = Node(                                                                          
         name='rq_camera_node',
-        package="usb_cam",
-        executable="usb_cam_node_exe",
-        parameters=[camera_params],
+        package="camera_ros",
+        executable="camera_node",
         respawn=True,
         respawn_delay=5
     )
+
+    #
+    # For a generic USB webcam
+    #
+    #rq_camera_node = Node(
+    #    name='rq_camera_node',
+    #    package="usb_cam",
+    #    executable="usb_cam_node_exe",
+    #    parameters=[camera_params],
+    #    respawn=True,
+    #    respawn_delay=5
+    #)
 
     return LaunchDescription([rq_base_node,
                               rq_camera_node

--- a/launch/roboquest_core.launch.py
+++ b/launch/roboquest_core.launch.py
@@ -24,13 +24,16 @@ def generate_launch_description():
         respawn_delay=5
     )
 
+    # un-comment one camera and adjust the return statement below
+
     #
     # For the ArduCam/RasPiCam
     #
-    rq_camera_node = Node(                                                                          
+    rq_camera_node = Node(
         name='rq_camera_node',
         package="camera_ros",
         executable="camera_node",
+        parameters=[camera_params],
         respawn=True,
         respawn_delay=5
     )

--- a/roboquest_core/rq_motors.py
+++ b/roboquest_core/rq_motors.py
@@ -46,9 +46,8 @@ class RQMotors(object):
 
         GPIO.setmode(GPIO.BCM)
         GPIO.setup(MOTOR_ENABLE_PIN, GPIO.OUT)
-        # TODO: Change the default to disabled
-        GPIO.output(MOTOR_ENABLE_PIN, GPIO.HIGH)
-        self._motors_enabled = True
+        GPIO.output(MOTOR_ENABLE_PIN, GPIO.LOW)
+        self._motors_enabled = False
 
     def _setup_i2c(self) -> None:
         """

--- a/scripts/camera_fps.py
+++ b/scripts/camera_fps.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+FRAMES = 100
+FORMAT = 'jpeg'
+#WIDTH = 3280
+#HEIGHT = 2464
+WIDTH = 640
+HEIGHT = 480
+
+import io
+import time
+from picamera2 import Picamera2
+
+picam2 = Picamera2()
+
+"""
+{'use_case': 'still', 'transform': <libcamera.Transform 'identity'>, 'colour_space':
+<libcamera.Colo
+rSpace 'sYCC'>, 'buffer_count': 1, 'queue': True, 'main': {'format': 'BGR888',
+'size': (3280, 2464)}
+, 'lores': None, 'raw': {'format': 'SBGGR10_CSI2P', 'size': (3280, 2464)},
+'controls': {'NoiseReduct
+ionMode': <NoiseReductionModeEnum.HighQuality: 2>, 'FrameDurationLimits': (100,
+1000000000)}, 'displ
+ay': None, 'encode': None}
+"""
+
+capture_config = picam2.create_still_configuration()
+capture_config['main']['size'] = (WIDTH, HEIGHT)
+capture_config['raw']['size'] = (WIDTH, HEIGHT)
+picam2.configure(capture_config)
+picam2.start()
+
+start = time.time()
+print(f"Start time {start}")
+
+data = io.BytesIO()
+bytes_collected = 0
+for frame in range(FRAMES):
+    picam2.capture_file(data, format=FORMAT)
+    bytes_collected += data.getbuffer().nbytes
+
+end = time.time()
+
+print(f"{FORMAT} Frames per second = {FRAMES / (end - start)}")
+print(f"Frame average size {bytes_collected / FRAMES}")
+
+metadata_jpg = picam2.capture_file(f"{WIDTH}x{HEIGHT}.jpg")
+metadata_png = picam2.capture_file(f"{WIDTH}x{HEIGHT}.png")

--- a/scripts/dstart.sh
+++ b/scripts/dstart.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+#
+# Start the docker container for roboquest_core
+#
+
+IMAGE=$1
+NAME=rq_core
+
+printf "Starting %s on %s\n" "$IMAGE" $DOCKER_HOST
+
+docker run -d --rm \
+        --privileged \
+        --network host \
+        --ipc host \
+        --device /dev/gpiomem:/dev/gpiomem \
+        --device /dev/i2c-1:/dev/i2c-1 \
+        --device /dev/i2c-6:/dev/i2c-6 \
+        --device /dev/ttyS0:/dev/ttyS0 \
+        -v /dev/shm:/dev/shm \
+        -v /var/run/dbus:/var/run/dbus \
+        -v /run/udev:/run/udev \
+        -v ros_logs:/root/.ros/log \
+        --name $NAME \
+        "$IMAGE"
+
+if [[ $? = 0 ]]
+then
+    docker container ls
+    printf "\nStarted\n"
+else
+    printf "Failed to start %s\n" $NAME
+fi
+
+exit 0

--- a/scripts/updater.py
+++ b/scripts/updater.py
@@ -29,6 +29,7 @@ Files and directories:
 
 VERSION = 5
 DIRECTORIES = ['/opt/persist', '/opt/updater']
+PERSIST_MNT = '/usr/src/ros2ws/install/roboquest_ui/share/roboquest_ui/public'
 UPDATE_LOG = '/opt/updater/updater.log'
 UPDATE_FIFO = '/tmp/update_fifo'
 UPDATE_VERSION = 'http://registry.q4excellence.com:8079/updater_version.txt'
@@ -37,6 +38,10 @@ UPDATE_URL = 'http://registry.q4excellence.com:8079/' + UPDATE_SCRIPT
 LOOP_PERIOD_S = 10.0
 EOL = '\n'
 
+#
+# When this dictionary is modified, remember to update both dstart.sh
+# scripts.
+#
 CONTAINERS = {
     'rq_core': {
         'image_name': 'registry.q4excellence.com:5678/rq_core',
@@ -55,7 +60,7 @@ CONTAINERS = {
         'devices': [],
         'volumes': ['/dev/shm:/dev/shm',
                     UPDATE_FIFO+':'+UPDATE_FIFO,
-                    '/opt:/tmp/opt',
+                    '/opt/persist:'+PERSIST_MNT,
                     'ros_logs:/root/.ros/log']}
 }
 

--- a/scripts/updater.py
+++ b/scripts/updater.py
@@ -29,7 +29,7 @@ Files and directories:
 
 VERSION = 5
 DIRECTORIES = ['/opt/persist', '/opt/updater']
-PERSIST_MNT = '/usr/src/ros2ws/install/roboquest_ui/share/roboquest_ui/public'
+PERSIST_MNT = '/usr/src/ros2ws/install/roboquest_ui/share/roboquest_ui/public/persist'
 UPDATE_LOG = '/opt/updater/updater.log'
 UPDATE_FIFO = '/tmp/update_fifo'
 UPDATE_VERSION = 'http://registry.q4excellence.com:8079/updater_version.txt'


### PR DESCRIPTION
Replaced the generic webcam and usb_cam package with the camera_ros package and support for the ArduCam.

The updater.py script was updated to create the PERSIST directory for future use by the Express server, to save user-modified configuration changes. Added docker configuration changes required by the camera_ros node.

Added the dstart.sh script for starting the docker container from the command line.

Changed the default startup state of the MOTORS to OFF.

There is probably a bug with the way updater.py determines a newer version of the image exists.

Required by both [roboquest PR 12](https://github.com/billmania/roboquest/pull/12) and [roboquest_ui PR 9](https://github.com/billmania/roboquest_ui/pull/9).