### PR TITLE
Corrected defects in hostname.bash and roboquest-hostname.service

### DIFF
--- a/scripts/hostname.bash
+++ b/scripts/hostname.bash
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Bill Mania, 15 Aug 2023
+#
+# Executed at boot to ensure the hostname is unique,
+# before requesting an IP address from the DHCP service.
+# It must be executed by systemd, not /etc/rc.local.
+#
+
+HOSTNAME_BASE="rq"
+
+logger -p user.notice  "hostname.bash started"
+printf "hostname.bash was started\n" >&2
+
+#
+# In order to create a unique hostname, append
+# the last 4 digits of the eth0 MAC address.
+#
+UNIQUE_HOST=$(ip address show dev eth0 scope link | \
+	       awk '/ether/{print $2}' | \
+	       sed 's/://g' | \
+	       grep -o '....$')
+HOSTNAME="$HOSTNAME_BASE-$UNIQUE_HOST"
+
+hostnamectl set-hostname ${HOSTNAME}
+
+logger -p user.notice  "Hostname set to $HOSTNAME"
+printf "Hostname set to %s\n" $HOSTNAME >&2
+
+exit 0

--- a/scripts/roboquest-hostname.service
+++ b/scripts/roboquest-hostname.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Setup the unique RoboQuest hostname
+Before=network-pre.target
+
+[Service]
+Type-oneshot
+Restart=no
+ExecStart=/usr/local/roboquest/hostname.bash
+
+[Install]
+WantedBy=network.target


### PR DESCRIPTION
The roboquest-hostname.service file is now placed into the correct directory and has the correct dependencies defined. hostname.bash uses the correct system utility to set the hostname each time the RaspPi boots, based on the Ethernet interface's MAC address.

To apply this fix to an existing system:

1. ssh to the base OS of the RaspPi
2. sudo -i
3. systemctl disable roboquest-hostname.service
4. _remove the roboquest-hostname.service from its current location in the filesystem, probably /etc/systemd/system_
5. replace /usr/local/roboquest/hostname.bash with the latest version from this branch
6. place roboquest-hostname.service from this branch into /lib/systemd/system
7. systemctl daemon-reload
8. systemctl enable roboquest-hostname.service
9. systemctl reboot

Tested by correcting the filesystem on a single microSD, manually setting the hostname with **hostnamectl set-hostname wrong** and then booting two separate RaspPis from the same microSD. Confirmed each host's hostname was set to match the current MAC address. Confirmed the full RoboQuest application functions correctly at http://rasppi4b:3456/rq_testing.html, even though the hostname is NOT in /etc/hosts.