### PR TITLE
Corrected defects in access_point.bash and roboquest-access-point.service

### DIFF
--- a/scripts/access_point.bash
+++ b/scripts/access_point.bash
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 #
-# Cory Duce, Nov 26 2020
-# Bill Mania updated, 24 Jan 2022
+# Bill Mania, 24 Jan 2022
 #
 # Executed at boot to ensure there is an Access Point setup to
-# allow wireless access to the robot.
+# allow wireless access to the robot. If the AP connection
+# doesn't exist, it is created. If it does exist, its SSID
+# definition is updated to match the current hardware.
 #
 
 NM_CONN_NAME="roboAP"
@@ -16,36 +17,48 @@ AP_PSK="roboquest"
 # the last 4 digits of the eth0 MAC address.
 #
 UNIQUE_MAC=$(ip address show dev eth0 scope link | \
-	      awk '/ether/{print $2}' | \
-	      sed 's/://g' | \
-	      grep -o '....$')
+              awk '/ether/{print $2}' | \
+              sed 's/://g' | \
+              grep -o '....$')
 AP_SSID="${AP_SSID_BASE}_${UNIQUE_MAC}"
 
-CONNECTION=$(nmcli -c no conn show | grep $NM_CONN_NAME)
-if [[ $CONNECTION != *"$NM_CONN_NAME"* ]]
+if ! nmcli -c no conn show $NM_CONN_NAME > /dev/null 2> /dev/null
 then
+    #
+    # The roboAP does not exist, so create it.
+    #
     logger -p user.notice "Defining Access Point:$AP_SSID"
     nmcli -c no \
-	conn add \
-	type wifi \
-	ifname wlan0 \
-	con-name $NM_CONN_NAME \
-	autoconnect no \
-	ssid $AP_SSID
+        conn add \
+        type wifi \
+        ifname wlan0 \
+        con-name $NM_CONN_NAME \
+        autoconnect no \
+        ssid $AP_SSID
     nmcli -c no \
-	conn modify $NM_CONN_NAME \
-	802-11-wireless.mode ap \
-	802-11-wireless.band bg \
-	ipv4.method shared
+        conn modify $NM_CONN_NAME \
+        802-11-wireless.mode ap \
+        802-11-wireless.band bg \
+        ipv4.method shared
     nmcli -c no \
-	conn modify $NM_CONN_NAME \
-	wifi-sec.key-mgmt wpa-psk
+        conn modify $NM_CONN_NAME \
+        wifi-sec.key-mgmt wpa-psk
     nmcli -c no \
-	conn modify $NM_CONN_NAME \
-	wifi-sec.psk $AP_PSK
+        conn modify $NM_CONN_NAME \
+        wifi-sec.psk $AP_PSK
 else
-        logger -p user.notice  "Access Point:$AP_SSID exists"
+    logger -p user.notice  "Access Point ${NM_CONN_NAME} exists"
+    ssid=$(nmcli -c no -t --fields 802-11-wireless.ssid conn show ${NM_CONN_NAME} \
+            | cut -d: -f2)
+    if [[ "${ssid}" != "${AP_SSID}" ]]
+    then
+        nmcli -c no conn mod ${NM_CONN_NAME} 802-11-wireless.ssid ${AP_SSID}
+        logger -p user.notice  " Set SSID to ${AP_SSID}"
+    fi
+
 fi
 
 nmcli -c no \
     conn up ifname wlan0
+
+exit 0

--- a/scripts/roboquest-access-point.service
+++ b/scripts/roboquest-access-point.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Setup the RoboQuest WiFi Access Point
+Wants=network-online.target
+After=network-online.target network.target
+
+[Service]
+Type=oneshot
+Restart=no
+ExecStart=/usr/local/roboquest/access_point.bash
+
+[Install]
+Wants=NetworkManager.service
+WantedBy=default.target


### PR DESCRIPTION
 Both the script and the service definition had defects which were causing them to NOT set the Access Point SSID at boot to the Ethernet MAC address.

To apply this fix to an existing system:

1. ssh to the base OS of the RaspPi
2. sudo -i
3. systemctl disable roboquest-network.service
4. remove the roboquest-network.service from its current location in the filesystem, probably /etc/systemd/system
5. replace /usr/local/roboquest/access-point.bash with the latest version from this branch
6. place roboquest-access-point.service from this branch into /lib/systemd/system
7. systemctl daemon-reload
8. systemctl enable roboquest-hostname.service
9. systemctl reboot

Tested by correcting the filesystem on a single microSD, manually setting the SSID with nmcli and then booting two separate RaspPis from the same microSD. Confirmed each host's roboAP SSID was set to match the current MAC address. Confirmed the roboAP exists using a mobile phone.