### PR TITLE
Changed the HAT serial port from /dev/ttyS0 to /dev/ttyAMA1

### DIFF
--- a/config/roboquest_base.yaml
+++ b/config/roboquest_base.yaml
@@ -1,7 +1,7 @@
 /**:
   ros__parameters:
     name: "roboquest_base_node"
-    hat_port: "/dev/ttyS0"
+    hat_port: "/dev/ttyAMA1"
     hat_data_rate: 38400
     hat_data_bits: 7
     hat_parity: 'N'


### PR DESCRIPTION
This will be docker image version 13.

Updated the serial used for communication between the RaspPi and the HAT v2. This change is NOT backward-compatible with the HAT v1.

Requires [roboquest PR 15](https://github.com/billmania/roboquest/pull/15)

Tested by building a new rq_core image, starting the container, and running v13 of rq_ui. Pointed the browser at http://rasppi4b:3456/index.html. Saw updating camera frames, updating battery voltage telemetry. Clicked the charger control buttons and saw the telemetry attributes change correctly.
