### PR TITLE
Reverse proxy and authentication for docker registry

### DIFF
--- a/scripts/lighttpd.conf
+++ b/scripts/lighttpd.conf
@@ -1,0 +1,88 @@
+server.modules = (
+  "mod_openssl",
+  "mod_auth",
+  "mod_authn_file",
+  "mod_accesslog",
+  "mod_setenv",
+  "mod_redirect",
+  "mod_proxy",
+)
+
+server.document-root = "/var/www/html"
+server.errorlog      = "/var/log/lighttpd/error.log"
+accesslog.filename   = "/var/log/lighttpd/access.log"
+server.pid-file      = "/run/lighttpd.pid"
+server.username      = "www-data"
+server.groupname     = "www-data"
+server.port          = 8079
+
+$HTTP["scheme"] == "http" {
+    $HTTP["host"] =~ "^(.*?)(:\d+)?$" {  ## %1 contains hostname without port
+        url.redirect = ("" => "https://%1:5678${url.path}${qsa}")
+        url.redirect-code = 308
+    }
+}
+
+#
+# Apache headers set
+# Header always set "Docker-Distribution-Api-Version" "registry/2.0"
+# Header onsuccess set "Docker-Distribution-Api-Version" "registry/2.0"
+# RequestHeader set X-Forwarded-Proto "https"
+#
+#setenv.add-response-header = ("Docker-Distribution-Api-Version" => "registry/2.0")
+#setenv.add-request-header = ("Docker-Distribution-Api-Version" => "registry/2.0")
+
+$SERVER["socket"] == ":5678" {
+  ssl.engine = "enable"
+  ssl.pemfile = "/root/.acme.sh/registry.q4excellence.com_ecc/fullchain.cer"
+  ssl.privkey = "/root/.acme.sh/registry.q4excellence.com_ecc/registry.q4excellence.com.key"
+}
+
+$HTTP["url"] =~ "^/v2" {
+  $HTTP["request-method"] =~ "^(POST|PUT|PATCH|DELETE)$" {
+    proxy.server = ( "" => ( ( "host" => "127.0.0.1", "port" => "5679" ) ) )
+    proxy.header = ( "upgrade" => "enable" )
+
+    auth.backend = "htpasswd" 
+    auth.backend.htpasswd.userfile = "/etc/lighttpd/docker_users.txt"
+    auth.require = ("/v2" => (
+       "method"  => "basic",
+       "realm"   => "Docker PUSH",
+       "require" => "valid-user" 
+    ))
+  }
+
+  $HTTP["request-method"] =~ "^(GET|HEAD)$" {
+    proxy.server = ( "" => ( ( "host" => "127.0.0.1", "port" => "5679" ) ) )
+    proxy.header = ( "upgrade" => "enable" )
+  }
+}
+
+$HTTP["url"] =~ "^/secure" {
+  $HTTP["request-method"] =~ "^(GET|HEAD|POST|PATCH|DELETE)$" {
+    auth.backend = "htpasswd" 
+    auth.backend.htpasswd.userfile = "/etc/lighttpd/docker_users.txt"
+    auth.require = ("/secure" => (
+       "method"  => "basic",
+       "realm"   => "Docker PUSH",
+       "require" => "valid-user" 
+    ))
+  }
+}
+
+# strict parsing and normalization of URL for consistency and security
+# https://redmine.lighttpd.net/projects/lighttpd/wiki/Server_http-parseoptsDetails
+# (might need to explicitly set "url-path-2f-decode" = "disable"
+#  if a specific application is encoding URLs inside url-path)
+server.http-parseopts = (
+  "url-normalize-unreserved"=> "enable",# recommended highly
+  "url-normalize-required"  => "enable",# recommended
+  "url-ctrls-reject"        => "enable",# recommended
+  "url-path-2f-decode"      => "enable",# recommended highly (unless breaks app)
+  "url-path-dotseg-remove"  => "enable",# recommended highly (unless breaks app)
+)
+
+# default listening port for IPv6 falls back to the IPv4 port
+include_shell "/usr/share/lighttpd/use-ipv6.pl " + server.port
+include_shell "/usr/share/lighttpd/create-mime.conf.pl"
+include "/etc/lighttpd/conf-enabled/*.conf"

--- a/scripts/registry_test.sh
+++ b/scripts/registry_test.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+export DOCKER_HOST=tcp://192.168.0.24:2376
+
+#
+# Any http request is redirected to https
+#
+curl --verbose -X GET -L http://registry.q4excellence.com:8079/test
+# 1 OK
+
+
+#
+# GET http://registry.q4excellence.com:8079/updater_version.txt
+# redirects to https and returns a string
+#
+curl --verbose -X GET -L http://registry.q4excellence.com:8079/updater_version.txt
+# 1 OK
+
+#
+# GET http://registry.q4excellence.com:8079/updater.py
+# redirects to https and returns the Python script
+#
+curl --verbose -X GET -L http://registry.q4excellence.com:8079/updater.py
+# 1 OK
+
+#
+# curl -X GET https://registry.q4excellence.com:5678/v2/_catalog
+# returns something very similar to:
+# {"repositories":["rq_core","rq_ui"]}
+#
+curl --verbose -X GET -L http://registry.q4excellence.com:8079/v2/_catalog
+curl --verbose -X GET https://registry.q4excellence.com:5678/v2/_catalog
+# 1 OK
+
+#
+# docker pull registry.q4excellence.com:5678/rq_core
+# retrieves the image
+#
+docker pull registry.q4excellence.com:5678/rq_core
+# 1 OK
+
+#
+# Python docker module image PULL
+#
+# 1 OK
+
+#
+# test authentication with GET +, HEAD +, PUT 403, POST +, PATCH 403,
+# DELETE 403
+# docker pull does GET and HEAD
+# docker push does GET, HEAD, and PUT
+#
+curl --verbose -X GET -u push:UpYoursNow https://registry.q4excellence.com:5678/secure/put_test
+# 1 OK
+
+#
+# docker push registry.q4excellence.com:5678/rq_core
+# requires authentication and pushes the image to the registry
+#
+docker login -u push registry.q4excellence.com:5678
+docker push push/registry.q4excellence.com:5678/rq_core
+# 1 FAIL
+
+exit 0


### PR DESCRIPTION
Configure the lighttpd server running on registry.q4excellence.com as a reverse proxy for the docker registry service. This change was made in order to implement limited access control to the registry. Pulls from the registry do not require authentication but pushes so. Unfortunately **docker login** and **docker push** don't yet work with the authentication as configured in lighttpd.conf. The temporary work around is to disable authentication at the registry just long enough to push a new image.

All of the Use Cases for the lighttpd web server and registry proxy are listed in scripts/registry_test.sh. They all pass except for the **docker push**.

These files aren't needed by the roboquest_core docker image, so the version number will not be incremented.