### PR TITLE
Set the camera FPS

### DIFF
--- a/config/rq_camera.yaml
+++ b/config/rq_camera.yaml
@@ -3,6 +3,7 @@
     height: 480
     width: 640
     role: still
+    FrameDurationLimits: [ 100000, 100000 ]
     qos_overrides:
       /parameter_events:
         publisher:


### PR DESCRIPTION
This will be roboquest_core version 13.

It's possible to indirectly set the FPS of the ArduCam by using some camera_ros parameters. When AeEnable and ExposureTime are null (not set), FrameDurationLimits can be used to define the FPS.
FrameDurationLimits is a list of two integers. They are both microseconds. The first is the minimum duration of a frame capture and the second is the maximum. Therefore, setting FrameDurationLimits to 
[ 100000, 100000 ] constrains the camera_ros node to publishing camera frames at about 10 Hz.

Tested by starting the node and then running
```
ros2 topic hz /rq_camera_node/image_raw/compressed
```