### PR TITLE
Disable the damping on servo motion

### DIFF
--- a/roboquest_core/rq_servos.py
+++ b/roboquest_core/rq_servos.py
@@ -174,9 +174,10 @@ class RQServos(object):
                                     angle,
                                     servo.joint_angle_max_deg)
 
-            angle = self._slow_motion(
-                self._servos_state[servo.channel]['angle'],
-                angle)
+            #
+            # This is the spot where the _slow_motion() method could be
+            # inserted.
+            #
 
             pulse_duration_ms = self._translate(
                 angle,


### PR DESCRIPTION
Disbled the RQServos._slow_motion() method so commands to move servos aren't damped. The servo motion is now as fast as the servo can move from its current position to the commanded position. Multiple commands to move a servo to a specific angle now function no differently than a single command.

Tested by starting rq_core and rq_ui, using the browser UI to enable the servos, and then using
```
ros2 topic pub /servos rq_msgs/msg/ServoAngles '"servos": [{"name": "camera_pan", "angle": 70}]'
```
to publish onto /servos. Also used rqt to watch for any error or complaints.

This is Issue #23 