### PR TITLE
Catch the TranslateError exception from RQServos._translate

### DIFF
--- a/roboquest_core/rq_manage.py
+++ b/roboquest_core/rq_manage.py
@@ -8,7 +8,7 @@ from geometry_msgs.msg import TwistStamped
 from roboquest_core.rq_node import RQNode
 from roboquest_core.rq_hat import RQHAT
 from roboquest_core.rq_motors import RQMotors
-from roboquest_core.rq_servos import RQServos
+from roboquest_core.rq_servos import RQServos, TranslateError
 from roboquest_core.rq_network import RQNetwork
 from roboquest_core.rq_hat import TELEM_HEADER, SCREEN_HEADER
 from roboquest_core.rq_hat import HAT_SCREEN, HAT_BUTTON
@@ -83,7 +83,13 @@ class RQManage(RQNode):
 
         # TODO: Refactor this into putting the commands in a queue
         for servo in msg.servos:
-            self._servos.set_servo_angle(servo.name, servo.angle)
+            try:
+                self._servos.set_servo_angle(servo.name, servo.angle)
+
+            except TranslateError as e:
+                self.get_logger().warning(
+                    f"set_servo_angle: {e}",
+                    throttle_duration_sec=60)
 
     def _motor_cb(self, msg: TwistStamped):
         """

--- a/roboquest_core/rq_servos.py
+++ b/roboquest_core/rq_servos.py
@@ -227,9 +227,12 @@ class RQServos(object):
                 # angle so the following call may cause high acceleration
                 # of the servo angle.
                 #
-                self.set_servo_angle(
-                    channel,
-                    servo.joint_angle_init_deg)
+                try:
+                    self.set_servo_angle(
+                        channel,
+                        servo.joint_angle_init_deg)
+                except TranslateError:
+                    pass
             else:
                 self.disable_servo(channel)
 


### PR DESCRIPTION
The rq_servos_config.py file provides a means to specify a minimum an maximum allowed angle for each servo. The RQServos._translate() method enforces those limits and raises an Exception when they're violated. v13rc3 of roboquest_core was not catching the Exception, therefore the base node would abort and be restarted by the launch daemon.

The defect was corrected by catching and logging the TranslateError exception.

Tested by running all the software, powering the servos, and then moving the slider for camera_tilt to a value outside the min and max constraints. Instead of aborting, the base node now logs the violation and otherwise ignore that particular command. The log entries are throttled, so as not to overwhelm the log file.

This is Issue #26 