### PR TITLE
Reduced the subscription queue to 1 for both cmd_vel and servos

### DIFF
--- a/roboquest_core/rq_manage.py
+++ b/roboquest_core/rq_manage.py
@@ -2,6 +2,7 @@ from typing import List
 from rclpy.parameter import Parameter
 from rclpy import spin_once as ROSspin_once
 from rclpy import shutdown as ROSshutdown
+import rclpy.logging
 import diagnostic_msgs
 from geometry_msgs.msg import TwistStamped
 
@@ -37,6 +38,9 @@ class RQManage(RQNode):
     def __init__(self,
                  node_name: str = 'RQManage'):
         super().__init__(node_name)
+        rclpy.logging.set_logger_level(
+            node_name,
+            rclpy.logging.LoggingSeverity.DEBUG)
         self._setup_parameters()
 
         self._telem_sentences = 0
@@ -180,11 +184,11 @@ class RQManage(RQNode):
         self._motor_sub = self.create_subscription(TwistStamped,
                                                    'cmd_vel',
                                                    self._motor_cb,
-                                                   5)
+                                                   1)
         self._servo_sub = self.create_subscription(ServoAngles,
                                                    'servos',
                                                    self._servo_cb,
-                                                   18)
+                                                   1)
         self._control_srv = self.create_service(Control,
                                                 'control_hat',
                                                 self._control_cb)

--- a/scripts/roboquest_base_node.py
+++ b/scripts/roboquest_base_node.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 from rclpy import init as ROS_init
-import rclpy.logging
 from roboquest_core.rq_manage import RQManage
 
 """
@@ -17,10 +16,6 @@ def run(node_name: str = 'roboquest_base_node'):
     """
 
     ROS_init(args=None)
-    rclpy.logging.set_logger_level(
-        node_name,
-        rclpy.logging.LoggingSeverity.DEBUG)
-
     rq_manage = RQManage(node_name)
     rq_manage.main()
     rq_manage.hat.cleanup_gpio()


### PR DESCRIPTION
In order to reduce the delay between moving the joystick or slider and the corresponding change in the motors or servos, the inbound subscription queue size was reduced to 1. This is a brute-force response to messages coming from the source faster than they can be processed. This change is likely treating only a symptom and not the actual cause.

Also moved the logging configuration into RQManage.