### PR TITLE
Stripped the CIDR portion from the IP address

### DIFF
--- a/roboquest_core/rq_network.py
+++ b/roboquest_core/rq_network.py
@@ -1,4 +1,5 @@
 from typing import Callable
+from re import sub as resub
 import subprocess
 
 from roboquest_core.rq_hat import HAT_SCREEN, HAT_BUTTON, EOL
@@ -248,7 +249,8 @@ class RQNetwork(object):
         output = self._pad_line(f"Name: {connection['DEVICE']}")
         if connection_type == 'active':
             try:
-                output += self._pad_line(f"IP: {connection['IP4.ADDRESS[1]']}")
+                ip_address = resub('/\d*$', '', connection['IP4.ADDRESS[1]'])
+                output += self._pad_line(f"IP: {ip_address}")
             except Exception as e:
                 self._logger(f"IP Exception {e}")
 


### PR DESCRIPTION
On HAT UI screen 2, Active Network Connections, the IP address assigned to the interface was displayed with the CIDR network size. Since this was confusing students, it was removed.

Tested by starting the application, changing the UI to screen 2, and observing the absence of the CIDR portion.

Issue #35