### PR TITLE
Fixed two defects affecting joystick motor control

### DIFF
--- a/roboquest_core/rq_manage.py
+++ b/roboquest_core/rq_manage.py
@@ -20,11 +20,12 @@ from rq_msgs.msg import ServoAngles
 
 VERSION = 3
 #
-# These two SCALE values are almost completely arbitrary. They
-# should be tuned based on the top speed of the drive motors.
+# These two SCALE values preserve the 0 to 100 speed control
+# values from the joystick.
 #
-LINEAR_SCALE = 30.0
-ANGULAR_SCALE = 20.0
+# TODO: Replace with parameters which transform values to m/s and rad/s.
+LINEAR_SCALE = 1
+ANGULAR_SCALE = 0.5
 
 
 class RQManage(RQNode):
@@ -133,17 +134,19 @@ class RQManage(RQNode):
         # The robot has a left and right motor commanded with units of
         # percentage of maximim rotational velocity.
         #
-        right_velocity = msg.twist.linear.x * LINEAR_SCALE
-        left_velocity = msg.twist.linear.x * LINEAR_SCALE
+        linear_velocity = msg.twist.linear.x * LINEAR_SCALE
+        right_velocity = linear_velocity
+        left_velocity = linear_velocity
 
+        angular_velocity = abs(msg.twist.angular.z) * ANGULAR_SCALE
         if msg.twist.angular.z > 0:
             # left turn
-            right_velocity += (msg.twist.angular.z * ANGULAR_SCALE)
-            left_velocity -= (msg.twist.angular.z * ANGULAR_SCALE)
+            right_velocity += angular_velocity
+            left_velocity -= angular_velocity
         else:
             # left turn
-            right_velocity -= (msg.twist.angular.z * ANGULAR_SCALE)
-            left_velocity += (msg.twist.angular.z * ANGULAR_SCALE)
+            right_velocity -= angular_velocity
+            left_velocity += angular_velocity
         self.get_logger().debug("motor_cb"
                                 f" right_velocity: {right_velocity}"
                                 f", left_velocity: {left_velocity}")

--- a/roboquest_core/rq_manage.py
+++ b/roboquest_core/rq_manage.py
@@ -18,7 +18,7 @@ from rq_msgs.msg import Telemetry
 from rq_msgs.msg import MotorSpeed
 from rq_msgs.msg import ServoAngles
 
-VERSION = 3
+VERSION = 4
 #
 # These two SCALE values preserve the 0 to 100 speed control
 # values from the joystick.


### PR DESCRIPTION
There were two separate defects with the way joystick velocity commands were transformed to individual motor velocity commands. One defect affected the variability of velocity and the other affected the ability to turn.

Removed some unnecessary floating point arithmetic, further reducing motor control latency by an additional small amount.

Tested by mounting the motors on a board, attaching their drive sprockets, and placing a tiny bit of yellow tape on each sprocket (to make direction and speed more easily visible). Fiddled with the motor speed control and then commanded via both joystick and keys. Motor speed control properly constrains both keys and joystick. Both keys and joystick spin the motors in a suitable direction. Lastly, joystick values from 0 to 100 affect the motor speed correctly.

Anecdotally, minimum motor speed is about 8% of maximum.

https://github.com/billmania/roboquest_core/issues/45