### PR TITLE
Create a persistent servo configuration file

### DIFF
--- a/persist/README_persist.md
+++ b/persist/README_persist.md
@@ -1,0 +1,1 @@
+# In the persist directory

--- a/roboquest_core/rq_config_file.py
+++ b/roboquest_core/rq_config_file.py
@@ -1,0 +1,116 @@
+"""
+Manage persistent configuration files.
+"""
+import pathlib
+from json import dumps, loads
+
+
+class ConfigFileError(Exception):
+    pass
+
+
+class ConfigFile(object):
+    """
+    Methods to initialize configuration files, retrieve them from persistent
+    storage, and update what's in persistent storage.
+    """
+
+    def __init__(self, persist_dir: str):
+        """
+        Ensure the persistent directory exists and is writable.
+        """
+
+        if not persist_dir:
+            raise ConfigFileError(
+                'Must provide a persistent directory path as a string')
+
+        self._persist_dir_path = pathlib.Path(persist_dir)
+        if (not self._persist_dir_path.exists()
+                or not self._persist_dir_path.is_dir()):
+            raise ConfigFileError(
+                f"${persist_dir} does not exist or is not a directory")
+
+    def init_config(self, config_file_name: str, config_data: object) -> None:
+        """
+        If config_file_name already exists in the persist_dir, return
+        without changing anything. If it doesn't exist, interpret
+        config_data as the object to save in the configuration file.
+        Create a file named config_name in the persist_dir, convert
+        config_data to a JSON string, and write it to the file.
+        """
+
+        config_file_path = self._persist_dir_path / config_file_name
+        if config_file_path.exists() and config_file_path.is_file():
+            return
+
+        config_file_path.unlink(missing_ok=True)
+        config_file_path.write_text(
+            dumps(
+                config_data,
+                sort_keys=True,
+                indent=2)
+        )
+
+    def get_config(self, config_file_name: str) -> object:
+        """
+        Get the contents of config_file_name and return it as an
+        object.
+        """
+
+        config_file_path = self._persist_dir_path / config_file_name
+        if config_file_path.exists() and config_file_path.is_file():
+            try:
+                return loads(config_file_path.read_text())
+            except Exception as e:
+                raise ConfigFileError(e)
+        else:
+            raise ConfigFileError(f"{config_file_name} does not exist")
+
+    def save_config(self, config_file_name: str, config_data: object) -> None:
+        """
+        Archive the current config_file_name and save the config_data
+        in its place.
+        """
+
+        self._archive_config(config_file_name)
+
+        config_file_path = self._persist_dir_path / config_file_name
+        try:
+            config_file_path.write_text(
+                dumps(
+                    config_data,
+                    sort_keys=True,
+                    indent=2
+                )
+            )
+        except Exception as e:
+            raise ConfigFileError(e)
+
+    def _archive_config(self, config_file_name: str):
+        """
+        Remove any old config_file_name and rename the current config_file_name
+        by appending ".old".
+        """
+
+        old_config_file_path = (
+            self._persist_dir_path / f"{config_file_name}.old"
+        )
+        old_config_file_path.unlink(missing_ok=True)
+        config_file_path = self._persist_dir_path / config_file_name
+        config_file_path.rename(old_config_file_path)
+
+
+if __name__ == '__main__':
+    cf = ConfigFile('/tmp')
+    cf.init_config(
+        'servos.config',
+        [{'name': 'camera_tilt', 'channel': 0},
+         {'name': 'camera_pan', 'channel': 1}]
+    )
+    print(cf.get_config('servos.config'))
+    cf.save_config(
+        'servos.config',
+        [{'name': 'camera_tilt', 'channel': 10},
+         {'name': 'camera_pan', 'channel': 11}]
+    )
+    print(cf.get_config('servos.config'))

--- a/roboquest_core/rq_config_file.py
+++ b/roboquest_core/rq_config_file.py
@@ -1,6 +1,7 @@
 """
 Manage persistent configuration files.
 """
+from typing import Callable
 import pathlib
 from json import dumps, loads
 
@@ -28,14 +29,17 @@ class ConfigFile(object):
         if (not self._persist_dir_path.exists()
                 or not self._persist_dir_path.is_dir()):
             raise ConfigFileError(
-                f"${persist_dir} does not exist or is not a directory")
+                f"{persist_dir} does not exist or is not a directory")
 
-    def init_config(self, config_file_name: str, config_data: object) -> None:
+    def init_config(
+         self,
+         config_file_name: str,
+         get_default_data: Callable) -> None:
         """
         If config_file_name already exists in the persist_dir, return
         without changing anything. If it doesn't exist, interpret
         config_data as the object to save in the configuration file.
-        Create a file named config_name in the persist_dir, convert
+        Create a file named config_file_name in the persist_dir, convert
         config_data to a JSON string, and write it to the file.
         """
 
@@ -46,7 +50,7 @@ class ConfigFile(object):
         config_file_path.unlink(missing_ok=True)
         config_file_path.write_text(
             dumps(
-                config_data,
+                get_default_data(),
                 sort_keys=True,
                 indent=2)
         )
@@ -54,7 +58,8 @@ class ConfigFile(object):
     def get_config(self, config_file_name: str) -> object:
         """
         Get the contents of config_file_name and return it as an
-        object.
+        object. The config file is expected to exist in the persistent
+        directory.
         """
 
         config_file_path = self._persist_dir_path / config_file_name

--- a/roboquest_core/rq_config_file.py
+++ b/roboquest_core/rq_config_file.py
@@ -38,9 +38,11 @@ class ConfigFile(object):
         """
         If config_file_name already exists in the persist_dir, return
         without changing anything. If it doesn't exist, interpret
-        config_data as the object to save in the configuration file.
+        get_default_data as the function to create a default servo
+        configuration object.
         Create a file named config_file_name in the persist_dir, convert
-        config_data to a JSON string, and write it to the file.
+        the servo configuration object to a JSON string, and write it to
+        the file.
         """
 
         config_file_path = self._persist_dir_path / config_file_name
@@ -74,7 +76,9 @@ class ConfigFile(object):
     def save_config(self, config_file_name: str, config_data: object) -> None:
         """
         Archive the current config_file_name and save the config_data
-        in its place.
+        in its place. This method is currently only used for testing because
+        rq_core doesn't save an updated servo configuration file - rq_ui
+        does that.
         """
 
         self._archive_config(config_file_name)

--- a/roboquest_core/rq_manage.py
+++ b/roboquest_core/rq_manage.py
@@ -20,7 +20,7 @@ from rq_msgs.msg import Telemetry
 from rq_msgs.msg import MotorSpeed
 from rq_msgs.msg import ServoAngles
 
-VERSION = 3
+VERSION = 4
 #
 # These two SCALE values preserve the 0 to 100 speed control
 # values from the joystick.
@@ -29,20 +29,9 @@ VERSION = 3
 LINEAR_SCALE = 1
 ANGULAR_SCALE = 0.5
 
-PERSIST_BASE_DIR="/usr/src/ros2ws/install/roboquest_core/share/roboquest_core"
-PERSIST_DIR=PERSIST_BASE_DIR + '/' + "persist"
-SERVO_CONFIG = 'servos_config.json'
-
-PERSIST_BASE_DIR="/usr/src/ros2ws/install/roboquest_core/share/roboquest_core"
-PERSIST_DIR=PERSIST_BASE_DIR + '/' + "persist"
-SERVO_CONFIG = 'servos_config.json'
-
-PERSIST_BASE_DIR="/usr/src/ros2ws/install/roboquest_core/share/roboquest_core"
-PERSIST_DIR=PERSIST_BASE_DIR + '/' + "persist"
-SERVO_CONFIG = 'servos_config.json'
-
-PERSIST_BASE_DIR="/usr/src/ros2ws/install/roboquest_core/share/roboquest_core"
-PERSIST_DIR=PERSIST_BASE_DIR + '/' + "persist"
+INSTALL_DIR = '/usr/src/ros2ws/install'
+PERSIST_BASE_DIR = INSTALL_DIR + '/roboquest_core/share/roboquest_core'
+PERSIST_DIR = PERSIST_BASE_DIR + '/persist'
 SERVO_CONFIG = 'servos_config.json'
 
 

--- a/roboquest_core/rq_manage.py
+++ b/roboquest_core/rq_manage.py
@@ -41,6 +41,10 @@ PERSIST_BASE_DIR="/usr/src/ros2ws/install/roboquest_core/share/roboquest_core"
 PERSIST_DIR=PERSIST_BASE_DIR + '/' + "persist"
 SERVO_CONFIG = 'servos_config.json'
 
+PERSIST_BASE_DIR="/usr/src/ros2ws/install/roboquest_core/share/roboquest_core"
+PERSIST_DIR=PERSIST_BASE_DIR + '/' + "persist"
+SERVO_CONFIG = 'servos_config.json'
+
 
 class RQManage(RQNode):
     """

--- a/roboquest_core/rq_manage.py
+++ b/roboquest_core/rq_manage.py
@@ -20,7 +20,7 @@ from rq_msgs.msg import Telemetry
 from rq_msgs.msg import MotorSpeed
 from rq_msgs.msg import ServoAngles
 
-VERSION = 5
+VERSION = 3
 #
 # These two SCALE values preserve the 0 to 100 speed control
 # values from the joystick.
@@ -28,6 +28,14 @@ VERSION = 5
 # TODO: Replace with parameters which transform values to m/s and rad/s.
 LINEAR_SCALE = 1
 ANGULAR_SCALE = 0.5
+
+PERSIST_BASE_DIR="/usr/src/ros2ws/install/roboquest_core/share/roboquest_core"
+PERSIST_DIR=PERSIST_BASE_DIR + '/' + "persist"
+SERVO_CONFIG = 'servos_config.json'
+
+PERSIST_BASE_DIR="/usr/src/ros2ws/install/roboquest_core/share/roboquest_core"
+PERSIST_DIR=PERSIST_BASE_DIR + '/' + "persist"
+SERVO_CONFIG = 'servos_config.json'
 
 PERSIST_BASE_DIR="/usr/src/ros2ws/install/roboquest_core/share/roboquest_core"
 PERSIST_DIR=PERSIST_BASE_DIR + '/' + "persist"

--- a/roboquest_core/rq_servos_config.py
+++ b/roboquest_core/rq_servos_config.py
@@ -1,11 +1,13 @@
 from typing import List
-from collections import namedtuple
 
 SERVO_QTY = 16
 
 """
 These configurations describe both the servo hardware and their
-constraints based on the way they're installed.
+constraints based on the way they're installed. This mechanism exists
+only as a way to create an initial or default servo configuration.
+The actual servo configuration is managed by the ConfigFile class and
+held in a persistent configuration file.
 
 In the Servo named tuple the attributes are grouped and described
 as follows:
@@ -30,98 +32,126 @@ joint_angle_max_deg - integer maximum possible angle for the joint
 
 """
 
-Servo = namedtuple('Servo',
-                   ['channel',
-                    'servo_make_model',
-                    'servo_angle_min_deg',
-                    'servo_angle_max_deg',
-                    'pulse_min_us',
-                    'pulse_max_us',
-                    'joint_name',
-                    'joint_init_wait_ms',
-                    'joint_angle_init_deg',
-                    'joint_angle_min_deg',
-                    'joint_angle_max_deg'
-                    ],
-                   defaults=[
-                       SERVO_QTY,
-                       'DSSERVO,DS3235SG',
-                       0,
-                       180,
-                       600,
-                       2400,
-                       None,
-                       50,
-                       90,
-                       0,
-                       180
-                   ])
 
-
-def servo_config() -> (List[Servo], dict, List[dict]):
+class Servo(object):
     """
-    Return three objects:
-        - a list of Servo named tuples, each of which describes a servo.
-        - a dictionary mapping servo names to the Servo named tuples
-        - a list of dictionaries with two attributes: enabled and angle;
+    The configuration details for a servo, managed as a dictionary to
+    support several requirements: write the details to a human-editable
+    JSON file; provide default values for all elements of the class;
+    instantiate the class with a variable quantity of arguments; provide
+    direct access to each member of the object.
+    """
 
-    All three objects contain SERVO_QTY instances. The two lists are
-    in servo channel order so they can be indexed by channel.
+    def __init__(
+         self,
+         channel=SERVO_QTY,
+         servo_make_model='DSSERVO,DS3235SG',
+         servo_angle_min_deg=0,
+         servo_angle_max_deg=180,
+         pulse_min_us=600,
+         pulse_max_us=2400,
+         joint_name=None,
+         joint_init_wait_ms=50,
+         joint_angle_init_deg=90,
+         joint_angle_min_deg=0,
+         joint_angle_max_deg=180
+         ):
+        """
+        Create the dictionary.
+        """
+
+        self._servo_config = dict()
+        self._servo_config['channel'] = channel
+        self._servo_config['servo_make_model'] = servo_make_model
+        self._servo_config['servo_angle_min_deg'] = servo_angle_min_deg
+        self._servo_config['servo_angle_max_deg'] = servo_angle_max_deg
+        self._servo_config['pulse_min_us'] = pulse_min_us
+        self._servo_config['pulse_max_us'] = pulse_max_us
+        self._servo_config['joint_name'] = joint_name
+        self._servo_config['joint_init_wait_ms'] = joint_init_wait_ms
+        self._servo_config['joint_angle_init_deg'] = joint_angle_init_deg
+        self._servo_config['joint_angle_min_deg'] = joint_angle_min_deg
+        self._servo_config['joint_angle_max_deg'] = joint_angle_max_deg
+
+    def get(self):
+        """
+        Return the Servo's dictionary.
+        """
+
+        return self._servo_config
+
+
+def servo_config() -> List[dict]:
+    """
+    Return a list of Servo dictionaries, each of which describes a servo.
     """
 
     servo_list = list()
-    name_map = dict()
-    servo_state_list = list()
     servo_list.append(Servo(channel=0,
                             joint_name='camera_pan',
-                            joint_init_wait_ms=0))
+                            joint_init_wait_ms=0).get())
     servo_list.append(Servo(channel=1,
                             servo_make_model='TIANKONGRC,MG995',
                             joint_name='camera_tilt',
                             joint_init_wait_ms=1000,
                             servo_angle_min_deg=50,
-                            pulse_max_us=2500))
+                            pulse_max_us=2500).get())
     servo_list.append(Servo(channel=2,
                             joint_name='shoulder_pan',
-                            joint_init_wait_ms=300))
+                            joint_init_wait_ms=300).get())
     servo_list.append(Servo(channel=3,
                             joint_name='shoulder_tilt',
-                            joint_angle_init_deg=40))
+                            joint_angle_init_deg=40).get())
     servo_list.append(Servo(channel=4,
                             joint_name='elbow',
-                            joint_angle_init_deg=90))
+                            joint_angle_init_deg=90).get())
     servo_list.append(Servo(channel=5,
                             joint_name='wrist_pan',
-                            joint_angle_init_deg=60))
+                            joint_angle_init_deg=60).get())
     servo_list.append(Servo(channel=6,
                             servo_make_model='TIANKONGRC,MG996R',
-                            joint_name='wrist_tilt'))
+                            joint_name='wrist_tilt').get())
     servo_list.append(Servo(channel=7,
                             servo_make_model='TIANKONGRC,MG995',
-                            joint_name='gripper_pan'))
+                            joint_name='gripper_pan').get())
     servo_list.append(Servo(channel=8,
                             joint_name='gripper',
                             joint_angle_max_deg=75,
-                            joint_angle_init_deg=0))
+                            joint_angle_init_deg=0).get())
     servo_list.append(Servo(channel=9,
-                            servo_make_model=None))
+                            servo_make_model=None).get())
     servo_list.append(Servo(channel=10,
-                            servo_make_model=None))
+                            servo_make_model=None).get())
     servo_list.append(Servo(channel=11,
-                            servo_make_model=None))
+                            servo_make_model=None).get())
     servo_list.append(Servo(channel=12,
-                            servo_make_model=None))
+                            servo_make_model=None).get())
     servo_list.append(Servo(channel=13,
-                            servo_make_model=None))
+                            servo_make_model=None).get())
     servo_list.append(Servo(channel=14,
-                            servo_make_model=None))
+                            servo_make_model=None).get())
     servo_list.append(Servo(channel=15,
-                            servo_make_model=None))
+                            servo_make_model=None).get())
+
+    return servo_list
+
+
+def servo_map_and_state(servo_list: List[dict]) -> (dict, list):
+    """
+    Accept as input the list of servos and return two things:
+    - a dictionary mapping each servo name to the corresponding servo
+      dictionary
+    - a list of dictionaries, one for each servo in channel number order,
+      which holds the current state of that servo
+    """
+
+    name_map = dict()
+    servo_state_list = list()
 
     for servo in servo_list:
-        name_map[servo.joint_name] = servo
+        name_map[servo['joint_name']] = servo
         servo_state_list.append(
             {'enabled': False,
-             'angle': servo.joint_angle_init_deg})
+             'angle': servo['joint_angle_init_deg']})
 
-    return servo_list, name_map, servo_state_list
+    return name_map, servo_state_list

--- a/scripts/dstart.sh
+++ b/scripts/dstart.sh
@@ -6,6 +6,7 @@
 
 IMAGE=$1
 NAME=rq_core
+PERSIST_DIR="/usr/src/ros2ws/install/roboquest_core/share/roboquest_core/persist"
 
 printf "Starting %s on %s\n" "$IMAGE" $DOCKER_HOST
 
@@ -21,6 +22,7 @@ docker run -d --rm \
         -v /dev/shm:/dev/shm \
         -v /var/run/dbus:/var/run/dbus \
         -v /run/udev:/run/udev \
+        -v /opt/persist:${PERSIST_DIR} \
         -v ros_logs:/root/.ros/log \
         --name $NAME \
         "$IMAGE"


### PR DESCRIPTION
In order to support the ability to modify the servo configuration via the browser UI, the servo configuration used by rq_core must ultimately come from a persistent configuration file instead of directly from a source file.
Implemented the persist/servos_config.json file so the rq_ui browser UI can read, update, and save it.

In order for these configurations to take effect, the rq_core container must be restarted.

Tested by removing any servos_config.json file and starting the rq_core container. The file was created. Changed the content of the persistent file and confirmed the rq_core container read the change.