### PR TITLE
Added support for up to four simultaneous CSI/USB cameras

### DIFF
--- a/config/rq_camera0.yaml
+++ b/config/rq_camera0.yaml
@@ -1,0 +1,13 @@
+/**:
+  ros__parameters:
+    camera: 0
+    height: 480
+    width: 640
+    role: 'still'
+    qos_overrides:
+      /parameter_events:
+        publisher:
+          depth: 1
+          durability: 'volatile'
+          history: 'keep_last'
+          reliability: 'reliable'

--- a/config/rq_camera1.yaml
+++ b/config/rq_camera1.yaml
@@ -1,0 +1,13 @@
+/**:
+  ros__parameters:
+    camera: 1
+    height: 480
+    width: 640
+    role: still
+    qos_overrides:
+      /parameter_events:
+        publisher:
+          depth: 1
+          durability: volatile
+          history: keep_last
+          reliability: reliable

--- a/config/rq_camera2.yaml
+++ b/config/rq_camera2.yaml
@@ -1,0 +1,13 @@
+/**:
+  ros__parameters:
+    camera: 2
+    height: 480
+    width: 640
+    role: still
+    qos_overrides:
+      /parameter_events:
+        publisher:
+          depth: 1
+          durability: volatile
+          history: keep_last
+          reliability: reliable

--- a/config/rq_camera3.yaml
+++ b/config/rq_camera3.yaml
@@ -1,9 +1,9 @@
 /**:
   ros__parameters:
+    camera: 3
     height: 480
     width: 640
     role: still
-    FrameDurationLimits: [ 100000, 100000 ]
     qos_overrides:
       /parameter_events:
         publisher:

--- a/launch/roboquest_core.launch.py
+++ b/launch/roboquest_core.launch.py
@@ -39,8 +39,8 @@ def generate_launch_description():
         respawn_delay=5
     )
 
-    rq_camera_node = Node(
-        name='rq_camera_node',
+    rq_camera_node0 = Node(
+        name='rq_camera_node0',
         package="camera_ros",
         executable="camera_node",
         parameters=[camera0_params],
@@ -70,7 +70,7 @@ def generate_launch_description():
     )
 
     return LaunchDescription([rq_base_node,
-                              rq_camera_node,
+                              rq_camera_node0,
                               rq_camera_node1,
                               rq_camera_node2,
                               rq_camera_node3

--- a/launch/roboquest_core.launch.py
+++ b/launch/roboquest_core.launch.py
@@ -9,10 +9,25 @@ def generate_launch_description():
         'config',
         'roboquest_base.yaml'
     )
-    camera_params = os.path.join(
+    camera0_params = os.path.join(
         get_package_share_directory('roboquest_core'),
         'config',
-        'rq_camera.yaml'
+        'rq_camera0.yaml'
+    )
+    camera1_params = os.path.join(
+        get_package_share_directory('roboquest_core'),
+        'config',
+        'rq_camera1.yaml'
+    )
+    camera2_params = os.path.join(
+        get_package_share_directory('roboquest_core'),
+        'config',
+        'rq_camera2.yaml'
+    )
+    camera3_params = os.path.join(
+        get_package_share_directory('roboquest_core'),
+        'config',
+        'rq_camera3.yaml'
     )
 
     rq_base_node = Node(
@@ -24,32 +39,39 @@ def generate_launch_description():
         respawn_delay=5
     )
 
-    # un-comment one camera and adjust the return statement below
-
-    #
-    # For the ArduCam/RasPiCam
-    #
     rq_camera_node = Node(
         name='rq_camera_node',
         package="camera_ros",
         executable="camera_node",
-        parameters=[camera_params],
+        parameters=[camera0_params],
         respawn=True,
         respawn_delay=5
     )
-
-    #
-    # For a generic USB webcam
-    #
-    #rq_camera_node = Node(
-    #    name='rq_camera_node',
-    #    package="usb_cam",
-    #    executable="usb_cam_node_exe",
-    #    parameters=[camera_params],
-    #    respawn=True,
-    #    respawn_delay=5
-    #)
+    rq_camera_node1 = Node(
+        name='rq_camera_node1',
+        package="camera_ros",
+        executable="camera_node",
+        parameters=[camera1_params],
+        respawn=False
+    )
+    rq_camera_node2 = Node(
+        name='rq_camera_node2',
+        package="camera_ros",
+        executable="camera_node",
+        parameters=[camera2_params],
+        respawn=False
+    )
+    rq_camera_node3 = Node(
+        name='rq_camera_node3',
+        package="camera_ros",
+        executable="camera_node",
+        parameters=[camera3_params],
+        respawn=False
+    )
 
     return LaunchDescription([rq_base_node,
-                              rq_camera_node
+                              rq_camera_node,
+                              rq_camera_node1,
+                              rq_camera_node2,
+                              rq_camera_node3
                              ])

--- a/roboquest_core/rq_manage.py
+++ b/roboquest_core/rq_manage.py
@@ -25,7 +25,7 @@ from rq_msgs.msg import Telemetry
 from rq_msgs.msg import MotorSpeed
 from rq_msgs.msg import ServoAngles
 
-VERSION = 19
+VERSION = 20
 
 JOYSTICK_MAX = 100
 #


### PR DESCRIPTION
The camera can be a mix of CSI and USB. This is a brute-force solution because the launch file doesn't actually know in advance how many cameras are available. There is an implicit expectation of at least one camera.

Newly connected and newly disconnected cameras will be detected only when the robot is booted. USB cameras can be connected and disconnected at will, but the change will be detected only after booting the robot. The CSI camera will always be the last camera found (and therefore not the default) when it and one or more USB cameras are connected.

The RQ browser UI does not yet have any way to choose a specific camera. If there are multiple cameras connected and any of cameras 1 through 4 abort for any reason, they will not be automatically restarted. Only camera0 will be restarted if it aborts.

The ROS topics for the camera frames are:

1. /rq_camera_node0/image_raw/compressed
2. /rq_camera_node1/image_raw/compressed
3. /rq_camera_node2/image_raw/compressed
4. /rq_camera_node3/image_raw/compressed

Only rq_camera_node0 will always exist. The other three will exist only when those cameras are connected or briefly at startup.

Required by [rq_ui PR 132](https://github.com/billmania/roboquest_ui/pull/132)

https://github.com/billmania/roboquest_core/issues/59