### PR TITLE
Command servos by angle, increment, or speed

### DIFF
--- a/roboquest_core/rq_manage.py
+++ b/roboquest_core/rq_manage.py
@@ -23,9 +23,9 @@ from std_srvs.srv import Empty
 from rq_msgs.srv import Control
 from rq_msgs.msg import Telemetry
 from rq_msgs.msg import MotorSpeed
-from rq_msgs.msg import ServoAngles
+from rq_msgs.msg import Servos
 
-VERSION = 20.1
+VERSION = 21
 
 JOYSTICK_MAX = 100
 #
@@ -111,16 +111,12 @@ class RQManage(RQNode):
         self.get_logger().fatal("_exit_worker: Calling kill")
         kill(getpid(), SIGKILL)
 
-    def _servo_cb(self, msg: ServoAngles) -> None:
+    def _servo_cb(self, msg: Servos) -> None:
         """
-        Extract the requested angle for each named servo and
-        send them to the servo controller. This method could need
-        a long time to run, dependent upon the configuration of the
-        servo delays and the quantity of servo commands in the
-        message.
-        Servo angle commands which are outside the configured
-        range of the servo are silently ignored. Commands to servos
-        which are currently disabled are silently ignored, too.
+        Extract the command for each servo and send them to the
+        servo controller. This method could need a long time to
+        run, dependent upon the configuration of the servo delays
+        and the quantity of servo commands in the message.
         """
 
         if not self._servos.controller_powered():
@@ -128,10 +124,19 @@ class RQManage(RQNode):
                                       throttle_duration_sec=60)
             return
 
-        # TODO: Refactor this into putting the commands in a queue
-        for servo in msg.servos:
+        for servo_id in self._servo_list:
+            servo = getattr(msg, servo_id)
+            if servo.command_type == 'X':
+                continue
+
             try:
-                self._servos.set_servo_angle(servo.name, servo.angle)
+                if servo.name:
+                    which_servo = servo.name
+                else:
+                    which_servo = servo_id.replace('servo', '')
+
+                if servo.command_type == 'A':
+                    self._servos.set_servo_angle(which_servo, servo.angle_deg)
 
             except TranslateError as e:
                 self.get_logger().warning(
@@ -269,7 +274,16 @@ class RQManage(RQNode):
             'motor_speed',
             self._motor_speed_cb,
             1)
-        self._servo_sub = self.create_subscription(ServoAngles,
+        #
+        # Collect the servos specified in the Servos message,
+        # to optimize the callback.
+        #
+        self._servo_list = []
+        for servo in dir(Servos()):
+            if servo.find('servo') == 0:
+                self._servo_list.append(servo)
+
+        self._servo_sub = self.create_subscription(Servos,
                                                    'servos',
                                                    self._servo_cb,
                                                    1)

--- a/roboquest_core/rq_manage.py
+++ b/roboquest_core/rq_manage.py
@@ -48,6 +48,8 @@ INSTALL_DIR = '/usr/src/ros2ws/install'
 PERSIST_BASE_DIR = INSTALL_DIR + '/roboquest_core/share/roboquest_core'
 PERSIST_DIR = PERSIST_BASE_DIR + '/persist'
 SERVO_CONFIG = 'servos_config.json'
+COMMAND_IGNORE = 0
+COMMAND_ANGLE = 1
 
 
 class RQManage(RQNode):
@@ -126,16 +128,13 @@ class RQManage(RQNode):
 
         for servo_id in self._servo_list:
             servo = getattr(msg, servo_id)
-            if servo.command_type == 'X':
+            if servo.command_type == COMMAND_IGNORE:
                 continue
 
             try:
-                if servo.name:
-                    which_servo = servo.name
-                else:
-                    which_servo = servo_id.replace('servo', '')
+                which_servo = servo_id.replace('servo', '')
 
-                if servo.command_type == 'A':
+                if servo.command_type == COMMAND_ANGLE:
                     self._servos.set_servo_angle(which_servo, servo.angle_deg)
 
             except TranslateError as e:

--- a/roboquest_core/rq_manage.py
+++ b/roboquest_core/rq_manage.py
@@ -25,7 +25,7 @@ from rq_msgs.msg import Telemetry
 from rq_msgs.msg import MotorSpeed
 from rq_msgs.msg import ServoAngles
 
-VERSION = 20
+VERSION = 20.1
 
 JOYSTICK_MAX = 100
 #
@@ -237,7 +237,7 @@ class RQManage(RQNode):
             self._hat.fet1_control(set_fet1_on)
 
         if request.set_fet2 in valid_values:
-            set_fet2_on = True if request.set_fet1 == 'ON' \
+            set_fet2_on = True if request.set_fet2 == 'ON' \
                 else False
             self._hat.fet2_control(set_fet2_on)
 

--- a/roboquest_core/rq_manage.py
+++ b/roboquest_core/rq_manage.py
@@ -50,6 +50,7 @@ PERSIST_DIR = PERSIST_BASE_DIR + '/persist'
 SERVO_CONFIG = 'servos_config.json'
 COMMAND_IGNORE = 0
 COMMAND_ANGLE = 1
+COMMAND_INCR = 2
 
 
 class RQManage(RQNode):
@@ -135,7 +136,13 @@ class RQManage(RQNode):
                 which_servo = servo_id.replace('servo', '')
 
                 if servo.command_type == COMMAND_ANGLE:
-                    self._servos.set_servo_angle(which_servo, servo.angle_deg)
+                    self._servos.set_servo_angle(
+                        which_servo,
+                        servo.angle_deg)
+                elif servo.command_type == COMMAND_INCR:
+                    self._servos.incr_servo_angle(
+                        which_servo,
+                        servo.angle_incr_deg)
 
             except TranslateError as e:
                 self.get_logger().warning(

--- a/roboquest_core/rq_manage.py
+++ b/roboquest_core/rq_manage.py
@@ -175,9 +175,11 @@ class RQManage(RQNode):
                                       throttle_duration_sec=60)
             return
 
-        self.get_logger().debug("motor_cb"
-                                f" linear_x: {msg.twist.linear.x}"
-                                f", angular_z: {msg.twist.angular.z}")
+        self.get_logger().debug(
+            "motor_cb"
+            f" linear_x: {msg.twist.linear.x}"
+            f", angular_z: {msg.twist.angular.z}"
+        )
 
         #
         # The units for linear.x are meters per second and for angular.z

--- a/roboquest_core/rq_manage.py
+++ b/roboquest_core/rq_manage.py
@@ -99,7 +99,10 @@ class RQManage(RQNode):
         #
         self._servo_config = ConfigFile(PERSIST_DIR)
         self._servo_config.init_config(SERVO_CONFIG, servo_config)
-        self._servos = RQServos(self._servo_config.get_config(SERVO_CONFIG))
+        self._servos = RQServos(
+            self._servo_config.get_config(SERVO_CONFIG),
+            self.get_logger().warning,
+        )
 
         self._exit_timer = Timer(EXIT_DELAY_S, self._exit_worker)
 

--- a/roboquest_core/rq_manage.py
+++ b/roboquest_core/rq_manage.py
@@ -102,7 +102,7 @@ class RQManage(RQNode):
         self._servo_config.init_config(SERVO_CONFIG, servo_config)
         self._servos = RQServos(
             self._servo_config.get_config(SERVO_CONFIG),
-            self.get_logger().warning,
+            self.get_logger,
         )
 
         self._exit_timer = Timer(EXIT_DELAY_S, self._exit_worker)

--- a/roboquest_core/rq_manage.py
+++ b/roboquest_core/rq_manage.py
@@ -51,6 +51,7 @@ SERVO_CONFIG = 'servos_config.json'
 COMMAND_IGNORE = 0
 COMMAND_ANGLE = 1
 COMMAND_INCR = 2
+COMMAND_SPEED = 3
 
 
 class RQManage(RQNode):
@@ -146,6 +147,16 @@ class RQManage(RQNode):
                     self._servos.incr_servo_angle(
                         which_servo,
                         servo.angle_incr_deg)
+                elif servo.command_type == COMMAND_SPEED:
+                    self.get_logger().info(
+                        '_servo_cb:'
+                        f' servo: {which_servo}'
+                        f' speed: {servo.speed_dps}'
+                    )
+                    self._servos.set_servo_speed(
+                        which_servo,
+                        servo.speed_dps
+                    )
 
             except TranslateError as e:
                 self.get_logger().warning(

--- a/roboquest_core/rq_servos.py
+++ b/roboquest_core/rq_servos.py
@@ -1,5 +1,6 @@
 from typing import Union, List
-from time import sleep
+from time import sleep, time
+from threading import Thread, Lock, Event
 
 import smbus2
 
@@ -34,6 +35,8 @@ MAX_PULSE_US = 20000
 MIN_COUNT = 0
 MAX_COUNT = 4095
 PULSE_ON_COUNT = MIN_COUNT
+MOVE_PERIOD_S = 5.0
+INIT_DELAY_S = 0.05
 
 #
 # PCA9685 constants
@@ -70,7 +73,7 @@ class RQServos(object):
     bus.
     """
 
-    def __init__(self, servos: List[dict]):
+    def __init__(self, servos_list: List[dict], logger=print):
         """
         Setup communication with the servo sub-system. The PCA9685 I2C
         servo controller isn't configured until it's powered and then
@@ -79,12 +82,43 @@ class RQServos(object):
 
         self._write_errors = 0
 
-        self._servos = servos
-        self._name_map, self._servos_state = servo_map_and_state(self._servos)
+        self._servos_list = servos_list
+        self._logger = logger
+        #
+        # self._servos_list is a list of Servo objects, indexed by their
+        # position in the list. Their index position corresponds with their
+        # servo channel number.
+        #
+        # self._servo_name_map is a dictionary of Servo objects, keyed by the
+        # servo joint_name. It's a map from the joint_name to the Servo object.
+        #
+        # self._servos_state_list is a list of objects (not Servo objects)
+        # which track the current state of the servo. These objects are indexed
+        # by their position in the list, which corresponds again with their
+        # servo channel number.
+        #
+        self._servo_name_map, self._servos_state_list = (
+            servo_map_and_state(self._servos_list)
+        )
         self._controller_powered = False
 
         self._setup_gpio()
         self._setup_i2c()
+        self._servo_changed = Event()
+        self._servo_changed.clear()
+        self._servo_lock = Lock()
+        self._servo_period = Thread(
+            group=None,
+            target=self._time_servos,
+            name='servos_timer',
+            daemon=None)
+        self._servo_worker = Thread(
+            group=None,
+            target=self._move_servos,
+            name='servos_worker',
+            daemon=None)
+        self._servo_worker.start()
+        self._servo_period.start()
 
     def _setup_gpio(self) -> None:
         """
@@ -135,18 +169,19 @@ class RQServos(object):
         based on a desired angle.
         """
 
-        self._bus.write_byte_data(I2C_DEVICE_ID,
-                                  PULSE0_ON_L_REG+4*channel,
-                                  on_count & 0xFF)
-        self._bus.write_byte_data(I2C_DEVICE_ID,
-                                  PULSE0_ON_H_REG+4*channel,
-                                  on_count >> 8)
-        self._bus.write_byte_data(I2C_DEVICE_ID,
-                                  PULSE0_OFF_L_REG+4*channel,
-                                  off_count & 0xFF)
-        self._bus.write_byte_data(I2C_DEVICE_ID,
-                                  PULSE0_OFF_H_REG+4*channel,
-                                  off_count >> 8)
+        with self._servo_lock:
+            self._bus.write_byte_data(I2C_DEVICE_ID,
+                                      PULSE0_ON_L_REG+4*channel,
+                                      on_count & 0xFF)
+            self._bus.write_byte_data(I2C_DEVICE_ID,
+                                      PULSE0_ON_H_REG+4*channel,
+                                      on_count >> 8)
+            self._bus.write_byte_data(I2C_DEVICE_ID,
+                                      PULSE0_OFF_L_REG+4*channel,
+                                      off_count & 0xFF)
+            self._bus.write_byte_data(I2C_DEVICE_ID,
+                                      PULSE0_OFF_H_REG+4*channel,
+                                      off_count >> 8)
 
     def _get_servo(
             self,
@@ -160,7 +195,7 @@ class RQServos(object):
         try:
             channel_number = int(channel)
             if 0 <= channel_number < SERVO_QTY:
-                servo = self._servos[channel_number]
+                servo = self._servos_list[channel_number]
             else:
                 raise ServoError(
                     f"set_servo_angle: {channel_number} must be"
@@ -168,14 +203,99 @@ class RQServos(object):
                 )
 
         except ValueError:
-            if channel in self._name_map:
-                servo = self._name_map[channel]
+            if channel in self._servo_name_map:
+                servo = self._servo_name_map[channel]
             else:
                 raise ServoError(
                     f"set_servo_angle: {channel} not a recognized servo name"
                 )
 
         return servo
+
+    def _time_servos(self) -> None:
+        """
+        Set the _servo_changed Event every MOVE_PERIOD_S seconds.
+        """
+
+        while True:
+            self._servo_changed.set()
+            sleep(MOVE_PERIOD_S)
+
+    def _move_servos(self) -> None:
+        """
+        Executed by a separate thread and controlled by an Event.
+
+        Loops through self._servos_state_list to set the commanded angles
+        and update the current angle for each servo.  Since there isn't
+        any feedback from the servo about its current angle and there
+        isn't any information about the servo's rate of loaded or
+        unloaded change, the record of the servo's current angle is a
+        crude guess at best.
+        """
+
+        while True:
+            self._servo_changed.wait()
+            self._servo_changed.clear()
+            if not self._controller_powered:
+                continue
+
+            for channel, servo_state in enumerate(self._servos_state_list):
+                if not servo_state['enabled']:
+                    continue
+
+                servo = self._servos_list[channel]
+                command_angle = (
+                    servo_state['command_angle']
+                )
+
+                if command_angle == servo_state['angle']:
+                    servo_state['command_timestamp'] = time()
+                    continue
+
+                try:
+                    pulse_duration_ms = self._translate(
+                        command_angle,
+                        servo['servo_angle_min_deg'],
+                        servo['servo_angle_max_deg'],
+                        servo['pulse_min_us'],
+                        servo['pulse_max_us'])
+
+                    pulse_off_count = self._translate(
+                        pulse_duration_ms,
+                        MIN_PULSE_US,
+                        MAX_PULSE_US,
+                        MIN_COUNT,
+                        MAX_COUNT)
+
+                except TranslateError as e:
+                    self._logger(
+                        f'_move_servos: {e}'
+                    )
+                    continue
+
+                self._logger(
+                    f'_move_servos: channel {channel}, angle {command_angle}'
+                )
+                self._set_servo_pwm(
+                    channel,
+                    PULSE_ON_COUNT,
+                    round(pulse_off_count))
+                servo_state['angle'] = command_angle
+                servo_state['command_timestamp'] = time()
+
+    def set_servo_speed(
+            self,
+            channel: Union[int, str],
+            degrees_per_sec: float = 0.0) -> None:
+        """
+        Cause the servo to move away from its current position at the
+        rate degrees_per_sec until stopped or a limit is reached. A
+        thread is used to continue the motion until it's stopped.
+        Motion can be stopped by any of: setting degrees_per_sec to
+        0.0; calling incr_servo_angle; calling set_servo_angle.
+        """
+        # TODO: Implement
+        pass
 
     def incr_servo_angle(
             self,
@@ -188,91 +308,78 @@ class RQServos(object):
         """
 
         servo = self._get_servo(channel)
-        new_angle = (self._servos_state[servo['channel']]['angle'] +
+        new_angle = (self._servos_state_list[servo['channel']]['angle'] +
                      increment_deg)
-        self.set_servo_angle(channel, new_angle)
+        angle = self._constrain(servo['joint_angle_min_deg'],
+                                new_angle,
+                                servo['joint_angle_max_deg'])
+        self._servos_state_list[servo['channel']]['command_angle'] = angle
+        self._servo_changed.set()
 
     def set_servo_angle(self,
                         channel: Union[int, str],
-                        angle: int = None) -> int:
+                        angle: int = None) -> None:
         """
         Servos can be identified by: a string name; a string representation
         of the channel number; or an integer channel number.
 
         For servo channel set its angle. If no angle is provided, set
         the default angle. The default is the previously set angle.
-
-        The flow is from an angle in degrees, to a pulse duration
-        in microseconds, and finally to a register value in "counts".
-
-        The return value is the angle to which the servo was actually
-        moved, after limiting the acceleration.
         """
 
         servo = self._get_servo(channel)
-        if (self._controller_powered
-                and self._servos_state[servo['channel']]['enabled']):
-            if angle is None:
-                angle = self._servos_state[servo['channel']]['angle']
+        if angle is None:
+            angle = self._servos_state_list[servo['channel']]['angle']
 
-            angle = self._constrain(servo['joint_angle_min_deg'],
-                                    angle,
-                                    servo['joint_angle_max_deg'])
+        new_command_angle = self._constrain(
+            servo['joint_angle_min_deg'],
+            angle,
+            servo['joint_angle_max_deg']
+        )
 
-            pulse_duration_ms = self._translate(
-                angle,
-                servo['servo_angle_min_deg'],
-                servo['servo_angle_max_deg'],
-                servo['pulse_min_us'],
-                servo['pulse_max_us'])
+        servo_state = self._servos_state_list[servo['channel']]
+        if new_command_angle == servo_state['command_angle']:
+            return
 
-            pulse_off_count = self._translate(
-                pulse_duration_ms,
-                MIN_PULSE_US,
-                MAX_PULSE_US,
-                MIN_COUNT,
-                MAX_COUNT)
-
-            self._set_servo_pwm(
-                servo['channel'],
-                PULSE_ON_COUNT,
-                round(pulse_off_count))
-            self._servos_state[servo['channel']]['angle'] = angle
-
-            return angle
+        servo_state['command_angle'] = new_command_angle
+        self._servo_changed.set()
 
     def _pca9685_init(self):
         """
         Configure the PCA9685 for use, usually each time power is applied.
 
-        MODE1 to wake
-        MODE2 to totem pole
-        PRESCALE to 50 Hz
-
         Set the initial angle of each defined servo according to the
         configuration parameters.
         """
 
-        for register, value in SETUPS:
-            self._bus.write_byte_data(I2C_DEVICE_ID, register, value)
-            sleep(0.05)
+        with self._servo_lock:
+            for register, value in SETUPS:
+                self._bus.write_byte_data(I2C_DEVICE_ID, register, value)
+                sleep(INIT_DELAY_S)
 
-        for servo in self._servos:
-            channel = servo['channel']
-
+        for channel, servo in enumerate(self._servos_list):
             if servo['joint_name']:
-                self._servos_state[channel]['enabled'] = True
+                self._servos_state_list[channel]['enabled'] = True
                 #
                 # There isn't a way to know the servo's current
                 # angle so the following call may cause high acceleration
                 # of the servo angle.
                 #
                 try:
+                    servo_state = self._servos_state_list[channel]
                     self.set_servo_angle(
                         channel,
                         servo['joint_angle_init_deg'])
+                    servo_state['angle'] = servo['joint_angle_init_deg']
+                    servo_state['command_angle'] = (
+                        servo['joint_angle_init_deg']
+                    )
+                    servo_state['command_timestamp'] = time()
+
                 except TranslateError:
-                    pass
+                    servo_state['angle'] = None
+                    servo_state['command_angle'] = None
+                    servo_state['command_timestamp'] = None
             else:
                 self.disable_servo(channel)
 
@@ -290,7 +397,7 @@ class RQServos(object):
         is undone by restore_servo_angle().
         """
 
-        self._servos_state[channel]['enabled'] = False
+        self._servos_state_list[channel]['enabled'] = False
         self._set_servo_pwm(channel, 0, 0)
 
     def restore_servo_angle(self, channel: int) -> None:
@@ -300,7 +407,7 @@ class RQServos(object):
         """
 
         self.set_servo_angle(channel)
-        self._servos_state[channel]['enabled'] = True
+        self._servos_state_list[channel]['enabled'] = True
 
     def set_power(self, enable: bool = False) -> None:
         """
@@ -309,13 +416,13 @@ class RQServos(object):
 
         if (enable and not self._controller_powered):
             GPIO.output(SERVO_ENABLE_PIN, GPIO.HIGH)
-            sleep(0.5)
-            self._controller_powered = True
+            sleep(INIT_DELAY_S)
             self._pca9685_init()
+            self._controller_powered = True
 
         if (not enable and self._controller_powered):
-            GPIO.output(SERVO_ENABLE_PIN, GPIO.LOW)
             self._controller_powered = False
+            GPIO.output(SERVO_ENABLE_PIN, GPIO.LOW)
 
     def _constrain(self, min_value: int, value: int, max_value: int) -> int:
         """

--- a/roboquest_core/rq_servos_config.py
+++ b/roboquest_core/rq_servos_config.py
@@ -152,6 +152,8 @@ def servo_map_and_state(servo_list: List[dict]) -> (dict, list):
         name_map[servo['joint_name']] = servo
         servo_state_list.append(
             {'enabled': False,
-             'angle': servo['joint_angle_init_deg']})
+             'angle': servo['joint_angle_init_deg'],
+             'command_angle': None,
+             'command_timestamp': None})
 
     return name_map, servo_state_list

--- a/roboquest_core/rq_servos_config.py
+++ b/roboquest_core/rq_servos_config.py
@@ -154,6 +154,7 @@ def servo_map_and_state(servo_list: List[dict]) -> (dict, list):
             {'enabled': False,
              'angle': servo['joint_angle_init_deg'],
              'command_angle': None,
+             'command_dps': None,
              'command_timestamp': None})
 
     return name_map, servo_state_list


### PR DESCRIPTION
Replaced ServoAngle and ServoAngles with Servo and Servos, for angle commands. Servos can now be commanded to either:

1. Move to a specific angle
2. Increment the current angle and move to it
3. Move at a (sort of) constant rate

Motion 1 is most appropriate with a slider. 2 is appropriate for moving a servo with a button. 3 is intended for use with a joystick widget.

Tested using rqt to publish Servos messages with command_type 1, 2, and 3. Tested cmd_vel messages and motor_speed messages, with motors and servos off and on.

Requires [rq_msgs PR 9](https://github.com/billmania/rq_msgs/pull/9). Required by [rq_ui PR 133](https://github.com/billmania/roboquest_ui/pull/133)

Commit 4393df4385ec2484a3b8d3ec09fded35ff9906c7 passes Test Case 1 in [rq_ui Issue 130](https://github.com/billmania/roboquest_ui/issues/130)

Commit 6352bd9cc50ef490b77e46177911833c8b79e32e passes Test Case 1 in [rq_ui Issue 130](https://github.com/billmania/roboquest_ui/issues/130)

https://github.com/billmania/roboquest_core/issues/65