### PR TITLE
60 support sending update status messages to browser during an update

### DIFF
--- a/roboquest_core/rq_hat.py
+++ b/roboquest_core/rq_hat.py
@@ -132,7 +132,7 @@ class RQHAT(object):
         self._screen_page = 0
         self._status_lines = list()
 
-        self.status_msg('HAT setup')
+        self.status_msg('System status')
 
     def close(self):
         """

--- a/scripts/image_versions.json
+++ b/scripts/image_versions.json
@@ -1,0 +1,10 @@
+{
+  "registry.q4excellence.com:5678/rq_core":  {
+    "name": "rq_core",
+    "version": "v23"
+  },
+  "registry.q4excellence.com:5678/rq_ui": {
+    "name": "rq_ui",
+    "version": "v34"
+  }
+}

--- a/scripts/versions.json
+++ b/scripts/versions.json
@@ -1,0 +1,14 @@
+{
+    "installed": {
+        "rq_core": "v23",
+        "rq_ui": "v34",
+        "updater": "13",
+        "firmware": "6.1"
+    },
+    "available": {
+        "rq_core": "v23",
+        "rq_ui": "v34",
+        "updater": "14",
+        "firmware": "6.1"
+    }
+}


### PR DESCRIPTION
updater.py v14
Fixed the issue with updating updater.py and images. Now resumes the update after updater.py is restarted.
Fixed the issue with status messages during updates. Status messages now accumulate on the HAT UI.
Added support in updater.py for reading firmware_version.txt and image_versions.json on the registry server and then creating versions.json on the robot.
Updated RQHAT to show "System status" at startup instead of "HAT setup", but this change isn't deployed with updater.py.