### PR TITLE
Add support for available gpio pins

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>roboquest_core</name>
-  <version>0.1.0</version>
+  <version>0.24.0</version>
   <description>ROS2 package for the RoboQuest backend</description>
   <maintainer email="bill@manialabs.us">Bill Mania</maintainer>
   <license>Proprietary</license>

--- a/roboquest_core/rq_gpio_user.py
+++ b/roboquest_core/rq_gpio_user.py
@@ -11,11 +11,11 @@ class USER_GPIO_PIN(Enum):
     These are BCM numbers, not board numbers.
     """
 
-    GPIO6 = 6
-    GPIO16 = 16
-    GPIO19 = 19
-    GPIO20 = 20
-    GPIO26 = 26
+    gpio6 = 6
+    gpio16 = 16
+    gpio19 = 19
+    gpio20 = 20
+    gpio26 = 26
 
 
 class PinError(Exception):
@@ -56,9 +56,9 @@ class UserGPIO(object):
             return
 
         if pin in self._output_pins:
-            self._output_pins.remove()
+            self._output_pins.remove(pin)
         else:
-            self._input_pins.remove()
+            self._input_pins.remove(pin)
 
         GPIO.cleanup(pin.value)
         self._unused_pins.add(pin)
@@ -72,15 +72,12 @@ class UserGPIO(object):
 
         if pin in self._unused_pins:
             self._unused_pins.remove(pin)
-            self._output_pins.add(pin)
-            GPIO.setup(pin.value, GPIO.OUT)
         else:
             if pin in self._input_pins:
-                error = f'{pin.name} already set as input'
-            else:
-                error = f'{pin.name} already set as output'
+                self._input_pins.remove(pin)
 
-            raise PinError(error)
+        self._output_pins.add(pin)
+        GPIO.setup(pin.value, GPIO.OUT)
 
     def make_input(
          self,
@@ -91,15 +88,12 @@ class UserGPIO(object):
 
         if pin in self._unused_pins:
             self._unused_pins.remove(pin)
-            self._input_pins.add(pin)
-            GPIO.setup(pin.value, GPIO.IN)
         else:
-            if pin in self._input_pins:
-                error = f'{pin.name} already set as input'
-            else:
-                error = f'{pin.name} already set as output'
+            if pin in self._output_pins:
+                self._output_pins.remove(pin)
 
-            raise PinError(error)
+        self._input_pins.add(pin)
+        GPIO.setup(pin.value, GPIO.IN)
 
     def set_pin(self, pin: USER_GPIO_PIN, state: int = GPIO.LOW) -> Exception:
         """Set the value of an output pin.

--- a/roboquest_core/rq_gpio_user.py
+++ b/roboquest_core/rq_gpio_user.py
@@ -1,0 +1,127 @@
+"""Control of the user GPIO pins."""
+from enum import Enum
+from typing import List, Tuple
+
+import RPi.GPIO as GPIO
+
+
+class USER_GPIO_PIN(Enum):
+    """GPIO pins available to the user.
+
+    These are BCM numbers, not board numbers.
+    """
+
+    GPIO6 = 6
+    GPIO16 = 16
+    GPIO19 = 19
+    GPIO20 = 20
+    GPIO26 = 26
+
+
+class PinError(Exception):
+    """Describe error in pin configuration."""
+
+    pass
+
+
+class UserGPIO(object):
+    """Control user GPIO pins.
+
+    Provide user control of the GPIO pins.
+    """
+
+    def __init__(self):
+        """Initialize the structures."""
+        self._unused_pins = set()
+        self._output_pins = set()
+        self._input_pins = set()
+
+        for pin in USER_GPIO_PIN:
+            self._unused_pins.add(pin)
+
+    def _invalid_pin(self, pin: USER_GPIO_PIN) -> bool:
+        """Check the validity of a pin."""
+        return False if pin in USER_GPIO_PIN else True
+
+    def clear_pin(self, pin: USER_GPIO_PIN) -> None:
+        """Make a pin unused.
+
+        Ensure a pin is marked as unused. Calling this method on an already
+        unused pin is not an error.
+        """
+        if self._invalid_pin(pin):
+            raise PinError(f'{pin} not a valid pin')
+
+        if pin in self._unused_pins:
+            return
+
+        if pin in self._output_pins:
+            self._output_pins.remove()
+        else:
+            self._input_pins.remove()
+
+        GPIO.cleanup(pin.value)
+        self._unused_pins.add(pin)
+
+    def make_output(
+         self,
+         pin: USER_GPIO_PIN) -> Exception:
+        """Set a GPIO pin for output."""
+        if self._invalid_pin(pin):
+            raise PinError(f'{pin} not a valid pin')
+
+        if pin in self._unused_pins:
+            self._unused_pins.remove(pin)
+            self._output_pins.add(pin)
+            GPIO.setup(pin.value, GPIO.OUT)
+        else:
+            if pin in self._input_pins:
+                error = f'{pin.name} already set as input'
+            else:
+                error = f'{pin.name} already set as output'
+
+            raise PinError(error)
+
+    def make_input(
+         self,
+         pin: USER_GPIO_PIN) -> Exception:
+        """Set a GPIO pin for input."""
+        if self._invalid_pin(pin):
+            raise PinError(f'{pin} not a valid pin')
+
+        if pin in self._unused_pins:
+            self._unused_pins.remove(pin)
+            self._input_pins.add(pin)
+            GPIO.setup(pin.value, GPIO.IN)
+        else:
+            if pin in self._input_pins:
+                error = f'{pin.name} already set as input'
+            else:
+                error = f'{pin.name} already set as output'
+
+            raise PinError(error)
+
+    def set_pin(self, pin: USER_GPIO_PIN, state: int = GPIO.LOW) -> Exception:
+        """Set the value of an output pin.
+
+        Raise an exception if the pin isn't configured for output.
+        """
+        if self._invalid_pin(pin):
+            raise PinError(f'{pin} not a valid pin')
+
+        if pin not in self._output_pins:
+            raise PinError(f'{pin.name} not an output pin')
+
+        GPIO.output(pin.value, state)
+
+    def read_input_pins(self) -> List[Tuple]:
+        """Read the input pins.
+
+        Read the current value of each pin already configured as an input.
+        Return a list of tuples containing the pin and its value.
+        """
+        input_pin_values = []
+        for pin in self._input_pins:
+            input_pin_values.append((pin, GPIO.input(pin.value)))
+
+        return input_pin_values

--- a/roboquest_core/rq_manage.py
+++ b/roboquest_core/rq_manage.py
@@ -25,7 +25,7 @@ from rq_msgs.msg import Telemetry
 from rq_msgs.msg import MotorSpeed
 from rq_msgs.msg import Servos
 
-VERSION = '23'
+VERSION = '24rc1'
 
 JOYSTICK_MAX = 100
 #

--- a/roboquest_core/rq_servos.py
+++ b/roboquest_core/rq_servos.py
@@ -123,10 +123,12 @@ class RQServos(object):
         self._servo_period.start()
 
     def _setup_gpio(self) -> None:
-        """
-        Initialize the GPIO subsystem.
-        """
+        """Initialize the GPIO subsystem.
 
+        Initialize the GPIO subsystem. This class does not have exclusive
+        control of the GPIO subsystem.
+        """
+        GPIO.setwarnings(False)
         GPIO.setmode(GPIO.BCM)
         GPIO.setup(SERVO_ENABLE_PIN, GPIO.OUT)
         GPIO.output(SERVO_ENABLE_PIN, GPIO.LOW)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ package_name = 'roboquest_core'
 
 setup(
     name=package_name,
-    version='0.0.2',
+    version='0.24.0',
     packages=[package_name],
     data_files=[
         ('share/ament_index/resource_index/packages',


### PR DESCRIPTION
Added the GPIOInput and GPIOOutput interfaces. Added functionality to the roboquest_base_node to manage the GPIO pins. One topic, gpio_input,  delivers the current state of any pin configured as an input. A separate topic, gpio_output, provides the means to both configure the pins and to set the state of the output pins.
Pins can be configured as one of IN, OUT, or UNUSED. Output pins can be set to HIGH or LOW.
The frequency of GPIOInput messages on the gpio_input topic is the same as the frequency at which TELEM messages are published by the HAT.

The GPIO pins supported are 6, 16, 19, 20, and 26, using the BCM pin numbering scheme.

Tested on HAT hardware by connecting pins randomly to GND or 3V3. Tested output pins by connecting two pins, configuring one as input and the other as output, then setting and resetting the output pin.