### PR TITLE
Re-factored control of the I2C buses on the HAT

### DIFF
--- a/roboquest_core/rq_i2c.py
+++ b/roboquest_core/rq_i2c.py
@@ -1,0 +1,91 @@
+"""Use the Raspberry Pi I2C buses."""
+
+import smbus2
+
+
+class BusError(Exception):
+    """Describe an error with a bus."""
+
+    pass
+
+
+class DeviceError(Exception):
+    """Describe an error with a device."""
+
+    pass
+
+
+class RQI2CComms(object):
+    """
+    Communicate with I2C buses and devices.
+
+    Manages the operation of I2C bus devices as a singleton
+    object.
+    """
+
+    def __new__(cls):
+        """Ensure a singlton."""
+        if not hasattr(cls, 'instance'):
+            cls.instance = super(RQI2CComms, cls).__new__(cls)
+        return cls.instance
+
+    def __init__(self):
+        """Initialize the data structure."""
+        self._buses = {
+        }
+
+    def add_device(self, bus_ID: int, device_ID: int) -> None:
+        """Initialize communication with a device.
+
+        If bus_ID isn't already initialized, do so now. Record
+        the relationship between the device and bus.
+        """
+        if bus_ID not in self._buses:
+            try:
+                self._buses[bus_ID] = {
+                    'bus': smbus2.SMBus(bus_ID),
+                    'devices':  [device_ID]
+                }
+
+                return
+
+            except Exception:
+                raise BusError(f'Bus {bus_ID} excepted')
+
+        if device_ID not in self._buses[bus_ID]['devices']:
+            self._buses[bus_ID]['devices'].append(device_ID)
+
+            return
+
+        raise DeviceError(f'Device {device_ID} already added')
+
+    def write_block_data(
+         self,
+         bus_ID: int,
+         device_ID: int,
+         register_ID: int,
+         payload: list) -> None:
+        """Write the payload.
+
+        Write the bytes in payload to the bus_ID bus, for
+        device_ID device, to register_ID register.
+        """
+        if bus_ID not in self._buses:
+            raise BusError(f'Bus {bus_ID} not setup')
+        if device_ID not in self._buses[bus_ID]['devices']:
+            raise DeviceError(f'Device {device_ID} not setup')
+
+        try:
+            self._buses[bus_ID]['bus'].write_i2c_block_data(
+                device_ID,
+                register_ID,
+                payload
+            )
+
+        except Exception as e:
+            raise BusError(
+                f'Bus {bus_ID}'
+                f', device {device_ID}'
+                f', register {register_ID}'
+                f' exception {e.msg}'
+            )

--- a/roboquest_core/rq_i2c.py
+++ b/roboquest_core/rq_i2c.py
@@ -24,15 +24,15 @@ class RQI2CComms(object):
     """
 
     def __new__(cls):
-        """Ensure a singlton."""
+        """Ensure a singleton."""
         if not hasattr(cls, 'instance'):
             cls.instance = super(RQI2CComms, cls).__new__(cls)
+
         return cls.instance
 
     def __init__(self):
         """Initialize the data structure."""
-        self._buses = {
-        }
+        pass
 
     def add_device(self, bus_ID: int, device_ID: int) -> None:
         """Initialize communication with a device.
@@ -40,6 +40,9 @@ class RQI2CComms(object):
         If bus_ID isn't already initialized, do so now. Record
         the relationship between the device and bus.
         """
+        if not hasattr(self, '_buses'):
+            self._buses = {}
+
         if bus_ID not in self._buses:
             try:
                 self._buses[bus_ID] = {
@@ -59,13 +62,44 @@ class RQI2CComms(object):
 
         raise DeviceError(f'Device {device_ID} already added')
 
-    def write_block_data(
+    def write_byte_payload(
+         self,
+         bus_ID: int,
+         device_ID: int,
+         register_ID: int,
+         payload: int) -> None:
+        """Write the byte payload.
+
+        Write the byte in payload to the bus_ID bus, for
+        device_ID device, to register_ID register.
+        """
+        if bus_ID not in self._buses:
+            raise BusError(f'Bus {bus_ID} not setup')
+        if device_ID not in self._buses[bus_ID]['devices']:
+            raise DeviceError(f'Device {device_ID} not setup')
+
+        try:
+            self._buses[bus_ID]['bus'].write_byte_data(
+                device_ID,
+                register_ID,
+                payload
+            )
+
+        except Exception as e:
+            raise BusError(
+                f'Bus {bus_ID}'
+                f', device {device_ID}'
+                f', register {register_ID}'
+                f' exception {e.msg}'
+            )
+
+    def write_block_payload(
          self,
          bus_ID: int,
          device_ID: int,
          register_ID: int,
          payload: list) -> None:
-        """Write the payload.
+        """Write the block payload.
 
         Write the bytes in payload to the bus_ID bus, for
         device_ID device, to register_ID register.

--- a/roboquest_core/rq_manage.py
+++ b/roboquest_core/rq_manage.py
@@ -106,7 +106,7 @@ class RQManage(RQNode):
             self.get_logger().warning,
             self._hat.pad_line,
             self._hat.pad_text)
-        self._motors = RQMotors()
+        self._motors = RQMotors(self.get_logger)
         self._gpio = UserGPIO()
 
         #
@@ -118,7 +118,7 @@ class RQManage(RQNode):
         self._servo_config.init_config(SERVO_CONFIG, servo_config)
         self._servos = RQServos(
             self._servo_config.get_config(SERVO_CONFIG),
-            self.get_logger,
+            self.get_logger
         )
 
         self._exit_timer = Timer(EXIT_DELAY_S, self._exit_worker)

--- a/roboquest_core/rq_manage.py
+++ b/roboquest_core/rq_manage.py
@@ -207,7 +207,7 @@ class RQManage(RQNode):
                         which_servo,
                         servo.angle_incr_deg)
                 elif servo.command_type == COMMAND_SPEED:
-                    self.get_logger().info(
+                    self.get_logger().debug(
                         '_servo_cb:'
                         f' servo: {which_servo}'
                         f' speed: {servo.speed_dps}'
@@ -419,8 +419,6 @@ class RQManage(RQNode):
             return
 
         if not input_pins:
-            self.get_logger().info('_publish_gpio: No inputs to publish',
-                                   throttle_duration_sec=5.0)
             return
 
         gpio_msg = GPIOInput()

--- a/roboquest_core/rq_motors.py
+++ b/roboquest_core/rq_motors.py
@@ -5,7 +5,8 @@ from time import sleep
 
 import RPi.GPIO as GPIO
 
-import smbus2
+from roboquest_core.rq_i2c import BusError, DeviceError
+from roboquest_core.rq_i2c import RQI2CComms
 
 MAX_MOTOR_RPM = 300
 MOTOR_ENABLE_PIN = 17
@@ -50,8 +51,16 @@ class RQMotors(object):
         self._motors_enabled = False
 
     def _setup_i2c(self) -> None:
-        """Initialize the I2C bus."""
-        self._bus = smbus2.SMBus(I2C_BUS_ID)
+        """Initialize use of the I2C bus."""
+        try:
+            self._i2c = RQI2CComms()
+            self._i2c.add_device(I2C_BUS_ID, I2C_DEVICE_ID)
+
+        except BusError as e:
+            raise Exception(e.msg)
+
+        except DeviceError as e:
+            raise Exception(e.msg)
 
     def motors_are_enabled(self) -> bool:
         """Return True when the motors are enabled."""
@@ -101,12 +110,14 @@ class RQMotors(object):
             tries -= 1
 
             try:
-                self._bus.write_i2c_block_data(
+                self._i2c.write_block_data(
+                    I2C_BUS_ID,
                     I2C_DEVICE_ID,
                     I2C_MOTOR_RIGHT_REGISTER,
                     list(self._pack_rpm(self._constrain_rpm(right)))
                 )
-                self._bus.write_i2c_block_data(
+                self._i2c.write_block_data(
+                    I2C_BUS_ID,
                     I2C_DEVICE_ID,
                     I2C_MOTOR_LEFT_REGISTER,
                     list(self._pack_rpm(self._constrain_rpm(left)))


### PR DESCRIPTION
No new functionality was added. Re-factored control of the I2C buses by implementing the new class RQI2CComms as a singleton and then using it in both RQMotors and RQServos.
Confirmed it works with both motors and servos.

The RQI2CComms class will be used to add support for more I2C devices.