### PR TITLE
Integrate I2CSupport with RQManage

### DIFF
--- a/roboquest_core/rq_i2c_modules.py
+++ b/roboquest_core/rq_i2c_modules.py
@@ -1,0 +1,40 @@
+"""Dynamically import and instantiate any available I2C user modules."""
+from pathlib import Path
+from sys import path
+
+
+class I2CSupport(object):
+    """Manage the run-time I2C user modules."""
+
+    def __init__(self):
+        """Initialize the object."""
+        pass
+
+    def import_modules(self, module_dir: str) -> dict:
+        """Import I2C modules.
+
+        If the persistent directory exists and contains one or more
+        modules, import each one at a time and instantiate an object.
+
+        A dictionary is returned, containing a member for each
+        object instantiated. The key is the name of the class.
+        """
+        if not Path(module_dir).exists():
+            return {}
+
+        # TODO: May require an __init__.py in MODULE_DIR
+        path.append(module_dir)
+
+        i2c_objects = {}
+        for directory_entry in Path(module_dir).glob('*.py'):
+            if directory_entry.is_file():
+                module_name = directory_entry.name[:-3]
+                class_name = module_name
+
+                imported_module = __import__(module_name)
+                i2c_objects[module_name] = getattr(
+                    imported_module,
+                    class_name
+                )(class_name)
+
+        return i2c_objects

--- a/roboquest_core/rq_i2c_template.py
+++ b/roboquest_core/rq_i2c_template.py
@@ -1,0 +1,37 @@
+"""Template for a class which manages an I2C device."""
+
+
+class RQI2CDevice(object):
+    """Control an I2C device."""
+
+    def __init__(self, device_name: str):
+        """Initialize the object.
+
+        Handle everything needed to setup the object, but
+        don't do anything with the I2C bus.
+        """
+        self._device_name = device_name
+        print(f'Initialized object for {self._device_name}')
+
+        pass
+
+    def setup(self) -> None:
+        """Initialize the device.
+
+        The I2C bus is available when this method is called.
+        """
+        print(f'Setup device {self._device_name}')
+
+    def run_once(self) -> None:
+        """Run once each time through the RQManage loop.
+
+        Communicate with the I2C device in a non-blocking manner.
+        """
+        print(f'Ran device {self._device_name} once')
+
+    def cleanup(self) -> None:
+        """Stop the device.
+
+        The I2C bus is still available when this method is called.
+        """
+        print(f'Cleanup for device {self._device_name}')


### PR DESCRIPTION
The RQManage class now supports using the I2CSupport class to add user-provided I2C device classes to the rq_core ROS node. While this capability isn't used for anything more than a Proof of Concept for now, it will allow for the addition of I2C devices which are connected to the I2C bus(es) which are already connected to the servo and motor controllers. It eliminates having two separate processes controlling the same I2C bus.