### PR TITLE
Make I2C bus number assignment user configurable

### DIFF
--- a/config/i2c.yaml
+++ b/config/i2c.yaml
@@ -1,0 +1,4 @@
+/**:
+  ros__parameters:
+    servos_i2c_bus_id: 1
+    motors_i2c_bus_id: 6

--- a/launch/roboquest_core.launch.py
+++ b/launch/roboquest_core.launch.py
@@ -7,11 +7,39 @@ from launch_ros.actions import Node
 
 from pathlib import Path
 
+I2C_YAML_FILE = 'i2c.yaml'
+I2C_PARAM_FILE = (
+    '/usr/src/ros2ws/install/roboquest_core/share/roboquest_core/persist' +
+    '/i2c' +
+    '/' +
+    I2C_YAML_FILE
+)
+USER_LAUNCH_FILE = (
+    '/usr/src/ros2ws/install/roboquest_core/share/roboquest_core/persist' +
+    '/nodes' +
+    '/user_nodes.launch.py'
+)
+
+
 def generate_launch_description():
+    if Path(I2C_PARAM_FILE).exists():
+        src = Path(I2C_PARAM_FILE)
+        dest = (
+            Path(get_package_share_directory('roboquest_core')) /
+                'config' /
+            I2C_YAML_FILE
+        )
+        dest.write_text(src.read_text())
+
     base_params = os.path.join(
         get_package_share_directory('roboquest_core'),
         'config',
         'roboquest_base.yaml'
+    )
+    i2c_params = os.path.join(
+        get_package_share_directory('roboquest_core'),
+        'config',
+        'i2c.yaml'
     )
     camera0_params = os.path.join(
         get_package_share_directory('roboquest_core'),
@@ -38,7 +66,7 @@ def generate_launch_description():
         name='rq_base_node',
         package="roboquest_core",
         executable="roboquest_base_node.py",
-        parameters=[base_params],
+        parameters=[base_params, i2c_params],
         respawn=True,
         respawn_delay=5
     )
@@ -71,12 +99,6 @@ def generate_launch_description():
         executable="camera_node",
         parameters=[camera3_params],
         respawn=False
-    )
-
-    USER_LAUNCH_FILE = (
-        '/usr/src/ros2ws/install/roboquest_core/share/roboquest_core/persist' +
-        '/nodes' +
-        '/user_nodes.launch.py'
     )
 
     if Path(USER_LAUNCH_FILE).exists():

--- a/roboquest_core/rq_manage.py
+++ b/roboquest_core/rq_manage.py
@@ -115,7 +115,10 @@ class RQManage(RQNode):
             self.get_logger().warning,
             self._hat.pad_line,
             self._hat.pad_text)
-        self._motors = RQMotors(self.get_logger)
+        self._motors = RQMotors(
+            self._parameters['motors_i2c_bus_id'],
+            self.get_logger
+        )
         self._gpio = UserGPIO()
         self._i2c = RQI2CComms()
         self._i2c_support = I2CSupport()
@@ -141,6 +144,7 @@ class RQManage(RQNode):
         self._servo_config.init_config(SERVO_CONFIG, servo_config)
         self._servos = RQServos(
             self._servo_config.get_config(SERVO_CONFIG),
+            self._parameters['servos_i2c_bus_id'],
             self.get_logger
         )
 
@@ -410,7 +414,9 @@ class RQManage(RQNode):
             ('hat_data_bits', Parameter.Type.INTEGER),
             ('hat_parity', Parameter.Type.STRING),
             ('hat_stop_bits', Parameter.Type.INTEGER),
-            ('hat_comms_read_hz', Parameter.Type.INTEGER)
+            ('hat_comms_read_hz', Parameter.Type.INTEGER),
+            ('servos_i2c_bus_id', Parameter.Type.INTEGER),
+            ('motors_i2c_bus_id', Parameter.Type.INTEGER)
         ]
         self.declare_parameters(
             namespace='',

--- a/roboquest_core/rq_motors.py
+++ b/roboquest_core/rq_motors.py
@@ -10,6 +10,9 @@ from roboquest_core.rq_i2c import RQI2CComms
 
 MAX_MOTOR_RPM = 300
 MOTOR_ENABLE_PIN = 17
+#
+# This constant is only a default and can be overridden by i2c.yaml.
+#
 I2C_BUS_ID = 6
 I2C_DEVICE_ID = 0x53
 
@@ -27,8 +30,9 @@ class RQMotors(object):
     bus.
     """
 
-    def __init__(self, ros_logger):
+    def __init__(self, i2c_bus_id: int = I2C_BUS_ID, ros_logger=None):
         """Configure the motor control sub-system for use."""
+        self._i2c_bus_id = i2c_bus_id
         self._ros_logger = ros_logger
         self._write_errors = 0
         self.set_motor_max_rpm(MAX_MOTOR_RPM)
@@ -55,7 +59,7 @@ class RQMotors(object):
         """Initialize use of the I2C bus."""
         try:
             self._i2c = RQI2CComms()
-            self._i2c.add_device(I2C_BUS_ID, I2C_DEVICE_ID)
+            self._i2c.add_device(self._i2c_bus_id, I2C_DEVICE_ID)
 
         except BusError as e:
             self._ros_logger().warn(f'_setup_i2c: BusError({e})')
@@ -114,13 +118,13 @@ class RQMotors(object):
 
             try:
                 self._i2c.write_block_payload(
-                    I2C_BUS_ID,
+                    self._i2c_bus_id,
                     I2C_DEVICE_ID,
                     I2C_MOTOR_RIGHT_REGISTER,
                     list(self._pack_rpm(self._constrain_rpm(right)))
                 )
                 self._i2c.write_block_payload(
-                    I2C_BUS_ID,
+                    self._i2c_bus_id,
                     I2C_DEVICE_ID,
                     I2C_MOTOR_LEFT_REGISTER,
                     list(self._pack_rpm(self._constrain_rpm(left)))


### PR DESCRIPTION
[rq_core Issue 85](https://github.com/billmania/roboquest_core/issues/85)

The configuration file /opt/persist/i2c/i2c.yaml was added. The file contains two ROS parameters, servos_i2c_bus_id and motors_i2c_bus_id, which allow the user to define the I2C bus ID used by the servo and motor controller, respectively. Since the servo controller is hard-wired to bus1, i2c.yaml will normally be used to move the motor controller from bus 6 to bus 1, thereby freeing bus 6 for use by user nodes.