### PR TITLE
Corrected a minor bug in rq_network.py

### DIFF
--- a/roboquest_core/rq_manage.py
+++ b/roboquest_core/rq_manage.py
@@ -41,7 +41,7 @@ from rq_msgs.srv import Control
 
 from std_srvs.srv import Empty
 
-VERSION = '24rc1'
+VERSION = '24.1'
 
 MODULE_DIR = (
     '/usr/src/ros2ws'

--- a/roboquest_core/rq_network.py
+++ b/roboquest_core/rq_network.py
@@ -255,7 +255,7 @@ class RQNetwork(object):
             try:
                 output += self._pad_line(f"Dev: {connection['DEVICE']}")
                 ip_address = resub(
-                    '/\d*$',
+                    r'/\d*$',
                     '',
                     connection['IP4.ADDRESS[1]'])  # noqa: W605
                 output += self._pad_line(f"IP: {ip_address}")

--- a/scripts/dstart.sh
+++ b/scripts/dstart.sh
@@ -8,7 +8,7 @@ IMAGE=$1
 NAME=rq_core
 PERSIST_DIR="/usr/src/ros2ws/install/roboquest_core/share/roboquest_core/persist"
 
-printf "Starting %s on %s\n" "$IMAGE" $DOCKER_HOST
+printf "Starting %s on %s\n" "$IMAGE" "$(docker context show)"
 
 docker run -d --rm \
         --privileged \


### PR DESCRIPTION
Corrected a minor bug in rq_network.py where the "r" was missing from a regex used to remove part of an IP address. I wasn't able to confirm that this error was actually visible to the user, but it was causing complaints when building the rq_core image.

Updated the version in rq_manage.py to v24.1 (after failing to update to v24 for the previous release).

https://github.com/billmania/roboquest_core/issues/87