### PR TITLE
Motor control uses realistic values in the Twist message

### DIFF
--- a/config/roboquest_base.yaml
+++ b/config/roboquest_base.yaml
@@ -7,3 +7,9 @@
     hat_parity: 'N'
     hat_stop_bits: 1
     hat_comms_read_hz: 5
+    min_rpm: 5
+    max_rpm: 150
+    rpm_to_tps: 1.25
+    track_circumference: 0.680
+    track_separation: 0.225
+    sprocket_radius: 0.027

--- a/roboquest_core/rq_drive_utilities.py
+++ b/roboquest_core/rq_drive_utilities.py
@@ -25,12 +25,21 @@ class DriveUtils(object):
         ts is the distance between the centers of the two tracks,
            in meters
         """
-        self._SR = sr
-        self._TL = tl
-        self._TS = ts
+        scm = 2 * π * sr
+        AR = ts / 2
 
-        self._scm = 2 * π * self._SR
-        self._AR = self._TS / 2
+        self._linear_conversion = (
+            SECS_PER_MIN /
+            tl /
+            scm
+        )
+
+        self._angular_conversion = (
+            SECS_PER_MIN *
+            AR /
+            tl /
+            scm
+        )
 
     def angular_to_rpm(
         self,
@@ -46,11 +55,7 @@ class DriveUtils(object):
         negative of that value to the right sprocket.
         """
         return round(
-            angular_velocity *
-            SECS_PER_MIN *
-            self._AR /
-            self._TL /
-            self._scm
+            angular_velocity * self._angular_conversion
         )
 
     def linear_to_rpm(
@@ -63,8 +68,5 @@ class DriveUtils(object):
         return value is RPMs for both sprockets.
         """
         return round(
-            linear_velocity *
-            SECS_PER_MIN /
-            self._TL /
-            self._scm
+            linear_velocity * self._linear_conversion
         )

--- a/roboquest_core/rq_drive_utilities.py
+++ b/roboquest_core/rq_drive_utilities.py
@@ -1,0 +1,70 @@
+"""Utility functions for motion control.
+
+Convert a linear or angular velocity to drive sprocket RPMs.
+See https://github.com/billmania/roboquest_core/wiki/Robot-motion-calculations
+"""
+
+from math import pi as π
+
+SECS_PER_MIN = 60
+
+
+class DriveUtils(object):
+    """Hold utility functions for RPM."""
+
+    def __init__(
+        self,
+        sr: float,
+        tl: float,
+        ts: float
+    ):
+        """Initialize the constants.
+
+        sr is the radius of the drive sprocket in meters
+        tl is the length of the drive track in meters
+        ts is the distance between the centers of the two tracks,
+           in meters
+        """
+        self._SR = sr
+        self._TL = tl
+        self._TS = ts
+
+        self._scm = 2 * π * self._SR
+        self._AR = self._TS / 2
+
+    def angular_to_rpm(
+        self,
+        angular_velocity: float = 0.0
+    ) -> int:
+        """Convert angular velocity to RPM.
+
+        The angular_velocity input is interpreted as
+        radians per second AND a positive value is interpreted
+        as turning the bow to the left.
+
+        The return value is RPMs for the left sprocket. Apply the
+        negative of that value to the right sprocket.
+        """
+        return round(
+            angular_velocity *
+            SECS_PER_MIN *
+            self._AR /
+            self._TL /
+            self._scm
+        )
+
+    def linear_to_rpm(
+        self,
+        linear_velocity: float = 0.0
+    ) -> int:
+        """Convert linear velocity to RPM.
+
+        The linear velocity is interpreted as meters per second. The
+        return value is RPMs for both sprockets.
+        """
+        return round(
+            linear_velocity *
+            SECS_PER_MIN /
+            self._TL /
+            self._scm
+        )

--- a/roboquest_core/rq_manage.py
+++ b/roboquest_core/rq_manage.py
@@ -302,6 +302,7 @@ class RQManage(RQNode):
         right_velocity += angular_velocity
 
         self.get_logger().debug('motor_cb'
+                                f'       linear.x: {msg.twist.linear.x}'
                                 f' right_velocity: {right_velocity}'
                                 f', left_velocity: {left_velocity}')
 

--- a/roboquest_core/rq_motors.py
+++ b/roboquest_core/rq_motors.py
@@ -1,4 +1,4 @@
-"""Use the Raspberry Pi GPIO and I2C devices to control the motors."""
+"""Use the Raspberry Pi GPIO and I2C facilities to control the drive motors."""
 
 from struct import pack
 from time import sleep
@@ -8,40 +8,57 @@ import RPi.GPIO as GPIO
 from roboquest_core.rq_i2c import BusError, DeviceError
 from roboquest_core.rq_i2c import RQI2CComms
 
-MAX_MOTOR_RPM = 300
 MOTOR_ENABLE_PIN = 17
-#
-# This constant is only a default and can be overridden by i2c.yaml.
-#
-I2C_BUS_ID = 6
 I2C_DEVICE_ID = 0x53
 
-I2C_MOTOR_RIGHT_REGISTER = 3
-I2C_MOTOR_LEFT_REGISTER = 4
+I2C_MOTOR_LEFT_REGISTER = 3  # MOTOR1 connector
+I2C_MOTOR_RIGHT_REGISTER = 4  # MOTOR2 connector
 
 WRITE_ERROR_WAIT_S = 0.01
 
 
 class RQMotors(object):
-    """
-    Motor control.
+    """Control the drive motors.
 
     Manages the operation of the two drive motors connected to the I2C
-    bus.
+    bus. The velocity of the motors is set by taking an RPM as input,
+    converting it to a quantity of ticks per second, and then writing
+    the value to an I2C register, for each drive motor.
+    This class has no knowledge of the output sprocket dimensions, or
+    the length of the track. Therefore, it's the responsibility of the
+    calling object to map a meters per second (or radians per second)
+    value to RPM, before calling this class's set_motors_rpm method.
     """
 
-    def __init__(self, i2c_bus_id: int = I2C_BUS_ID, ros_logger=None):
+    def __init__(
+        self,
+        i2c_bus_id: int,
+        min_rpm: int,
+        max_rpm: int,
+        rpm_to_tps: float,
+        ros_logger=None
+    ):
         """Configure the motor control sub-system for use."""
         self._i2c_bus_id = i2c_bus_id
+        self._min_rpm = min_rpm
+        self._max_rpm = max_rpm
+        self._rpm_to_tps = rpm_to_tps
         self._ros_logger = ros_logger
         self._write_errors = 0
-        self.set_motor_max_rpm(MAX_MOTOR_RPM)
+        self.set_user_max_rpm(self._max_rpm)
 
         self._setup_gpio()
         self._setup_i2c()
 
-    def set_motor_max_rpm(self, max_rpm: int) -> None:
-        """Set the maximum RPM of the motors as a positive value."""
+    def set_user_max_rpm(self, max_rpm: int) -> None:
+        """Set the maximum RPM as a positive integer.
+
+        This method is provided to allow setting a maximum rpm
+        which is less than the hardware limit.
+        """
+        if max_rpm <= self._min_rpm or max_rpm > self._max_rpm:
+            return
+
         self._motor_max_rpm = max_rpm
 
     def _setup_gpio(self) -> None:
@@ -74,7 +91,11 @@ class RQMotors(object):
         return self._motors_enabled
 
     def enable_motors(self, enable: bool = False) -> None:
-        """Enable or disable the motors."""
+        """Enable or disable the motors.
+
+        The hardware immediately stops both motors when they're disabled.
+        It also resets the rpm for each motor to 0.
+        """
         if (enable and not self._motors_enabled):
             GPIO.output(MOTOR_ENABLE_PIN, GPIO.HIGH)
             sleep(0.2)
@@ -100,14 +121,20 @@ class RQMotors(object):
                    -self._motor_max_rpm)
 
     def set_motors_rpm(self, right: int = 0, left: int = 0) -> bool:
-        """Set RPM of motors.
+        """Set velocity of motors.
+
+        This method fails unless the motors are enabled.
 
         An open loop control for the velocity of each drive motor.
-        right and left are the RPM to set for each motor. A positive
-        value indicates the forward rotation.
+        It's assumed the motor control hardware has internal closed
+        loop PID control of the motor velocities.
+
+        right and left are the RPM to set for each motor.
+        A positive value is assumed to move the robot forward, ie.
+        in the positive x-axis direction.
 
         The velocity of the right motor is always set first, which
-        will likely have an impact on the robot's motion.
+        may have an impact on the robot's motion.
         """
         if not self._motors_enabled:
             return False
@@ -121,13 +148,25 @@ class RQMotors(object):
                     self._i2c_bus_id,
                     I2C_DEVICE_ID,
                     I2C_MOTOR_RIGHT_REGISTER,
-                    list(self._pack_rpm(self._constrain_rpm(right)))
+                    list(
+                        self._pack_rpm(
+                            self._constrain_rpm(
+                                right * self._rpm_to_tps
+                            )
+                        )
+                    )
                 )
                 self._i2c.write_block_payload(
                     self._i2c_bus_id,
                     I2C_DEVICE_ID,
                     I2C_MOTOR_LEFT_REGISTER,
-                    list(self._pack_rpm(self._constrain_rpm(left)))
+                    list(
+                        self._pack_rpm(
+                            self._constrain_rpm(
+                                left * self._rpm_to_tps
+                            )
+                        )
+                    )
                 )
 
                 return True


### PR DESCRIPTION
[Robot motion calculations](https://github.com/billmania/roboquest_core/wiki/Robot-motion-calculations)
[rq_core Issue 89](https://github.com/billmania/roboquest_core/issues/89)
Requires [rq_ui PR 157](https://github.com/billmania/roboquest_ui/pull/157)

This correction in rq_core requires an adjustment to the configuration of all of:

- UI motor control joystick widget
- UI maximum RPM slider widget
- gamepad

The scaling for the joystick must now be "-0.0256,0.003".

If a slider widget is configured for setting the motor maximum RPM, the max and default must be no greater than 150 (the motors aren't capable of any speed greater than 150 RPM).

If a gamepad is configured to control drive motors, the axis used to control forward and reverse motion must be scaled for a maximum forward value of 0.3 and maximum reverse value of -0.3. The axis used to control turning must be scaled for a maximum left turn value of 2.56 and right turn of -2.56. Forward is a positive value and left turn is a positive value.

It also requires the left drive motor is connected to the MOTOR1 header on the motor controller board.