### PR TITLE
Added a utility for testing the servo sub-system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ install(DIRECTORY config
 ament_python_install_package(${PROJECT_NAME})
 install(PROGRAMS
         scripts/roboquest_base_node.py
+        scripts/servo_tester_node.py
         DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/launch/servo_tester.launch.py
+++ b/launch/servo_tester.launch.py
@@ -1,0 +1,48 @@
+import os
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_ros.actions import Node
+
+from pathlib import Path
+
+I2C_YAML_FILE = 'i2c.yaml'
+I2C_PARAM_FILE = (
+    '/usr/src/ros2ws/install/roboquest_core/share/roboquest_core/persist' +
+    '/i2c' +
+    '/' +
+    I2C_YAML_FILE
+)
+
+def generate_launch_description():
+    if Path(I2C_PARAM_FILE).exists():
+        src = Path(I2C_PARAM_FILE)
+        dest = (
+            Path(get_package_share_directory('roboquest_core')) /
+                'config' /
+            I2C_YAML_FILE
+        )
+        dest.write_text(src.read_text())
+
+    base_params = os.path.join(
+        get_package_share_directory('roboquest_core'),
+        'config',
+        'roboquest_base.yaml'
+    )
+    i2c_params = os.path.join(
+        get_package_share_directory('roboquest_core'),
+        'config',
+        'i2c.yaml'
+    )
+
+    servo_tester_node = Node(
+        name='servo_tester_node',
+        package="roboquest_core",
+        executable="servo_tester_node.py",
+        parameters=[base_params, i2c_params],
+        respawn=True,
+        respawn_delay=5
+    )
+
+    return LaunchDescription([servo_tester_node])

--- a/roboquest_core/rq_manage.py
+++ b/roboquest_core/rq_manage.py
@@ -42,7 +42,7 @@ from rq_msgs.srv import Control
 
 from std_srvs.srv import Empty
 
-VERSION = '24.1rc5'
+VERSION = '24.1'
 
 MODULE_DIR = (
     '/usr/src/ros2ws'

--- a/roboquest_core/servo_tester.py
+++ b/roboquest_core/servo_tester.py
@@ -1,16 +1,13 @@
-"""Manage the core functionality of the RoboQuest backend.
+"""Test the servo control system.
 
-Control the features of the HAT, provide the ROS services and topics.
+Exercise the servos to either expose defects or prove
+functionality.
 """
 
 from os import getpid, kill
 from signal import SIGKILL
 from threading import Timer
-from typing import List
-
-import diagnostic_msgs
-
-from geometry_msgs.msg import TwistStamped
+from time import sleep
 
 import rclpy.logging
 from rclpy import ok as ROSok
@@ -19,28 +16,19 @@ from rclpy import spin_once as ROSspin_once
 from rclpy.parameter import Parameter
 
 from roboquest_core.rq_config_file import ConfigFile
-from roboquest_core.rq_drive_utilities import DriveUtils
-from roboquest_core.rq_gpio_user import PinError, USER_GPIO_PIN, UserGPIO
 from roboquest_core.rq_hat import HAT_BUTTON, HAT_SCREEN
 from roboquest_core.rq_hat import RQHAT
 from roboquest_core.rq_hat import SCREEN_HEADER, TELEM_HEADER
 from roboquest_core.rq_i2c import RQI2CComms
 from roboquest_core.rq_i2c_modules import I2CSupport
-from roboquest_core.rq_motors import RQMotors
-from roboquest_core.rq_network import RQNetwork
 from roboquest_core.rq_node import RQNode
 from roboquest_core.rq_servos import RQServos
 from roboquest_core.rq_servos import ServoError, TranslateError
 from roboquest_core.rq_servos_config import servo_config
 
-from rq_msgs.msg import GPIOInput
-from rq_msgs.msg import GPIOOutput
-from rq_msgs.msg import MotorSpeed
 from rq_msgs.msg import Servos
-from rq_msgs.msg import Telemetry
 from rq_msgs.srv import Control
 
-from std_srvs.srv import Empty
 
 VERSION = '24.1rc5'
 
@@ -66,31 +54,21 @@ COMMAND_INCR = 2
 COMMAND_SPEED = 3
 
 
-class RQManage(RQNode):
-    """Manage the ROS framework.
+class RQServoTest(RQNode):
+    """Test the servos.
 
-    The node which manages the RoboQuest application. It contains
-    all of the logic specific to management and use of the
-    RoboQuest HAT, network interfaces, motors, servos, and I2C
-    communications.
-
+    Exercises the servo sub-system.
     It requires rclpy.init() has already been called.
     """
 
     def __init__(self,
-                 node_name: str = 'RQManage'):
+                 node_name: str = 'RQServoTest'):
         """Initialize the object."""
         super().__init__(node_name)
         rclpy.logging.set_logger_level(
             node_name,
             rclpy.logging.LoggingSeverity.DEBUG)
         self._setup_parameters()
-
-        self._telem_sentences = 0
-        self._screen_sentences = 0
-        self._sentence_errors = 0
-
-        self._previous_screen = 0
 
         self._setup_ros_graph()
 
@@ -102,23 +80,6 @@ class RQManage(RQNode):
                           stop_bits=self._parameters['hat_stop_bits'],
                           read_timeout_sec=self._timeout_sec,
                           serial_errors_cb=None)
-        self._network = RQNetwork(
-            self.get_logger().warning,
-            self._hat.pad_line,
-            self._hat.pad_text)
-        self._motors = RQMotors(
-            self._parameters['motors_i2c_bus_id'],
-            self._parameters['min_rpm'],
-            self._parameters['max_rpm'],
-            self._parameters['rpm_to_tps'],
-            self.get_logger
-        )
-        self._drive_utils = DriveUtils(
-            self._parameters['sprocket_radius'],
-            self._parameters['track_circumference'],
-            self._parameters['track_separation']
-        )
-        self._gpio = UserGPIO()
         self._i2c = RQI2CComms()
         self._i2c_support = I2CSupport()
         self._i2c_objects = self._i2c_support.import_modules(MODULE_DIR)
@@ -159,49 +120,6 @@ class RQManage(RQNode):
         """
         self.get_logger().fatal('_exit_worker: Calling kill')
         kill(getpid(), SIGKILL)
-
-    def _gpio_output_cb(self, msg: GPIOOutput) -> None:
-        """Handle a GPIO configuration and output command.
-
-        Extract the contents of the GPIOOutput message. Use the _direction
-        parts to configure the GPIO pins as one of: input, output, or
-        idle. Use the _state parts to determine how to set each pin
-        configured as an output.
-        """
-        for gpio_pin in USER_GPIO_PIN:
-            direction = getattr(msg, gpio_pin.name+'_direction')
-            if direction == GPIOOutput.INPUT:
-                try:
-                    self._gpio.make_input(gpio_pin)
-                except PinError:
-                    self.get_logger().warning(
-                        '_gpio_output_cb: make_input PinError'
-                    )
-            elif direction == GPIOOutput.OUTPUT:
-                try:
-                    self._gpio.make_output(gpio_pin)
-                except PinError:
-                    self.get_logger().warning(
-                        '_gpio_output_cb: make_output PinError'
-                    )
-
-                try:
-                    self._gpio.set_pin(
-                        gpio_pin,
-                        getattr(msg, gpio_pin.name+'_state')
-                    )
-                except PinError:
-                    self.get_logger().warning(
-                        '_gpio_output_cb: set_pin PinError'
-                    )
-
-            elif direction == GPIOOutput.UNUSED:
-                try:
-                    self._gpio.clear_pin(gpio_pin)
-                except PinError:
-                    self.get_logger().warning(
-                        '_gpio_output_cb: clear_pin PinError'
-                    )
 
     def _servo_cb(self, msg: Servos) -> None:
         """Handle a servo command.
@@ -248,65 +166,6 @@ class RQManage(RQNode):
                     f'_servo_cb: {e}',
                     throttle_duration_sec=60)
 
-    def _motor_speed_cb(self, msg: MotorSpeed):
-        """Set the maximum motor speed."""
-        if not (0 <= msg.max_rpm <= self._parameters['max_rpm']):
-            self.get_logger().error(
-                'motor_speed_cb'
-                f' max: {msg.max_rpm}'
-                f" must be in [0, {self._parameters['max_rpm']}]"
-            )
-            return
-
-        self._motors.set_user_max_rpm(msg.max_rpm)
-
-    def _motor_cb(self, msg: TwistStamped):
-        """Handle a motor command.
-
-        Extract the linear.x and angular.z from the Twist message,
-        convert it to an x and y RPM, and pass it to the
-        motors controller.
-        """
-        if not self._motors.motors_are_enabled():
-            self.get_logger().warning('motors are not enabled',
-                                      throttle_duration_sec=60)
-            return
-
-        #
-        # The units for linear.x are meters per second and for angular.z
-        # are radians per second.
-        # The robot has a left and right motor, so this method uses
-        # linear.x and angular.z to calculate a net velocity for each
-        # of the two drive motors.
-        #
-        right_velocity = left_velocity = (
-            self._drive_utils.linear_to_rpm(msg.twist.linear.x)
-        )
-        angular_velocity = self._drive_utils.angular_to_rpm(
-            msg.twist.angular.z
-        )
-        left_velocity -= angular_velocity
-        right_velocity += angular_velocity
-
-        if not self._motors.set_motors_rpm(right=round(right_velocity),
-                                           left=round(left_velocity)):
-            self.get_logger().warning('failed to set motors RPM')
-
-    def _restart_cb(self, request, response):
-        """Handle a restart command.
-
-        Cause the node to exit, in order to have some other daemon
-        automatically restart it. This is usually done to load an
-        updated configuration.
-
-        In order for this callback to return a service response so
-        the caller doesn't hang, it uses a Timer to call exit().
-        """
-        self.get_logger().info('_restart_cb called')
-
-        self._exit_timer.start()
-        return response
-
     def _control_cb(self, request, response):
         """Handle a control command.
 
@@ -352,18 +211,6 @@ class RQManage(RQNode):
 
         Setup the publishers, subscribers, and services.
         """
-        self._telemetry_pub = self.create_publisher(Telemetry, 'telemetry', 1)
-        self._gpio_pub = self.create_publisher(GPIOInput, 'gpio_input', 1)
-        self._motor_sub = self.create_subscription(
-            TwistStamped,
-            'cmd_vel',
-            self._motor_cb,
-            1)
-        self._motor_speed_sub = self.create_subscription(
-            MotorSpeed,
-            'motor_speed',
-            self._motor_speed_cb,
-            1)
         #
         # Collect the servos specified in the Servos message,
         # to optimize the callback.
@@ -377,16 +224,9 @@ class RQManage(RQNode):
                                                    'servos',
                                                    self._servo_cb,
                                                    1)
-        self._gpio_sub = self.create_subscription(GPIOOutput,
-                                                  'gpio_output',
-                                                  self._gpio_output_cb,
-                                                  1)
         self._control_srv = self.create_service(Control,
                                                 'control_hat',
                                                 self._control_cb)
-        self._restart_srv = self.create_service(Empty,
-                                                'restart',
-                                                self._restart_cb)
 
     def _setup_parameters(self):
         parameter_declarations = [
@@ -421,56 +261,6 @@ class RQManage(RQNode):
             self.get_logger().info(f'Parameter {name}:'
                                    f' {self._parameters[name]}')
 
-    def _publish_gpio(self):
-        """Publish the current state of each GPIO input pin.
-
-        Read the current list of GPIO pins configured as input
-        and publish a message with each pins current state.
-        """
-        try:
-            input_pins = self._gpio.read_input_pins()
-        except PinError:
-            self.get_logger().warning(
-                '_publish_gpio: PinError for read_input_pins'
-            )
-            return
-
-        if not input_pins:
-            return
-
-        gpio_msg = GPIOInput()
-        gpio_msg.header.stamp = self.get_clock().now().to_msg()
-
-        for gpio_pin in input_pins:
-            self.get_logger().info(
-                '_publish_gpio:'
-                + f' {gpio_pin[0].name} = {gpio_pin[1]}',
-                throttle_duration_sec=5.0
-            )
-            setattr(gpio_msg, gpio_pin[0].name, gpio_pin[1])
-
-        self._gpio_pub.publish(gpio_msg)
-
-    def _publish_telemetry(self, fields: List[str]) -> None:
-        telemetry_msg = Telemetry()
-
-        telemetry_msg.header.stamp = self.get_clock().now().to_msg()
-
-        telemetry_msg.battery_v = float(fields[1])
-        telemetry_msg.battery_ma = float(fields[2])
-        telemetry_msg.system_ma = float(fields[3])
-        telemetry_msg.adc0_v = float(fields[4])
-        telemetry_msg.adc1_v = float(fields[5])
-        telemetry_msg.adc2_v = float(fields[6])
-        telemetry_msg.adc3_v = float(fields[7])
-        telemetry_msg.adc4_v = float(fields[8])
-        telemetry_msg.battery_charging, telemetry_msg.charger_has_power = \
-            self._hat.charger_state()
-        telemetry_msg.motors_on = self._motors.motors_are_enabled()
-        telemetry_msg.servos_on = self._servos.controller_powered()
-
-        self._telemetry_pub.publish(telemetry_msg)
-
     def _process_sentence(self, sentence: str):
         """Determine if it's a SCREEN or a TELEM sentence."""
         if sentence:
@@ -478,8 +268,6 @@ class RQManage(RQNode):
 
             if fields[0] == TELEM_HEADER:
                 if len(fields) == 9:
-                    self._publish_telemetry(fields)
-                    self._telem_sentences += 1
                     return
 
             elif fields[0] == SCREEN_HEADER:
@@ -515,48 +303,56 @@ class RQManage(RQNode):
                                   throttle_duration_sec=60)
         self._sentence_errors += 1
 
-    def _diags_cb(self, statuses):
-        """Assemble the collection of diagnostics."""
-        # TODO: Use something more informative for the Status
-        statuses.summary(
-            diagnostic_msgs.msg.DiagnosticStatus.OK,
-            'Telemetry')
-        statuses.add('telem_sentences', f'{self._telem_sentences}')
-        statuses.add('screen_sentences', f'{self._screen_sentences}')
-        statuses.add('sentence_errors', f'{self._sentence_errors}')
-
-        return statuses
-
     def main(self):
         """Configure the serial port.
 
         Configure and then read incoming sentences in a loop.
         """
         self.get_logger().info(f'{self._node_name} v{VERSION} starting')
-        self.setup_diags(diags_cb=self._diags_cb)
 
         self.get_logger().info(f'{self._node_name} spinning'
                                f' with timeout {self._timeout_sec}')
 
         self._hat.control_comms(enable=True)
         self._hat.charger_control(on=True)
-        while ROSok():
-            ROSspin_once(node=self, timeout_sec=0)
-            sentence = self._hat.read_sentence()
-            ROSspin_once(node=self, timeout_sec=0)
+        self._servos.set_power(False)
+        self._servos.set_power(True)
 
-            if sentence:
-                self._process_sentence(sentence)
+        SERVO_ID = 8
+        LOOP_PERIOD = 0.2
+        MIN_SERVO = 70
+        MAX_SERVO = 100
+        angle = MIN_SERVO
+        servo_increment = 2
+        try:
+            while ROSok():
+                ROSspin_once(node=self, timeout_sec=0)
 
-            self._publish_gpio()
-            if self._i2c_objects:
-                for i2c_object in self._i2c_objects:
-                    try:
-                        self._i2c_objects[i2c_object].run_once()
-                    except Exception as e:
-                        self.get_logger().warn(
-                            f'I2C {i2c_object} run_once() excepted: {e}'
-                        )
+                angle += servo_increment
+                self._servos.set_servo_angle(
+                    SERVO_ID,
+                    angle)
+
+    #            self._servos.incr_servo_angle(
+    #            self._servos.set_servo_speed(
+
+                if angle > MAX_SERVO:
+                    self.get_logger().info(
+                        f'MAX angle: {angle}, increment: {servo_increment}'
+                    )
+                    servo_increment = -(servo_increment)
+                    angle = MAX_SERVO
+                elif angle < MIN_SERVO:
+                    self.get_logger().info(
+                        f'MIN angle: {angle}, increment: {servo_increment}'
+                    )
+                    servo_increment = -(servo_increment)
+                    angle = MIN_SERVO
+
+                sleep(LOOP_PERIOD)
+
+        except KeyboardInterrupt:
+            self._servos.set_power(False)
 
         if self._i2c_objects:
             for i2c_object in self._i2c_objects:

--- a/scripts/servo_tester_node.py
+++ b/scripts/servo_tester_node.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Test servos."""
+from rclpy import init as ROS_init
+
+from roboquest_core.servo_tester import RQServoTest
+
+"""
+Instantiates the RQServoTest object and starts it.
+"""
+
+
+def run(node_name: str = 'servo_tester_node'):
+    """Create the node.
+
+    Initialize the ROS environment then instantiate the RQServoTest object
+    and set it in motion.
+    """
+    ROS_init(args=None)
+    rq_servo = RQServoTest(node_name)
+    rq_servo.main()
+
+
+if __name__ == '__main__':
+    run()

--- a/scripts/start_servo_test.sh
+++ b/scripts/start_servo_test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+cd /usr/src/ros2ws
+source /opt/ros/humble/setup.bash
+
+source install/setup.bash
+
+ros2 launch roboquest_core servo_tester.launch.py


### PR DESCRIPTION
[rq_core Issue 93](https://github.com/billmania/roboquest_core/issues/93)

roboquest_core/roboquest_core/servo_tester.py can exercise a specific servo, in each of the ANGLE, INCR, and SPEED modes. There is a multitude of constants at the top of the script, to choose a mode and set some operating parameters.

The launch file roboquest_core/launch/servo_tester.launch.py and script roboquest_core/scripts/start_servo_test.sh will load the necessary ROS parameters and start the node. It's simplest to build the roboquest_core docker image, with the CMD commented out, and then manual use the launch file from the command line inside the container.

ANGLE mode works precisely as expected.
INCR mode works precisely as expected.
SPEED mode works correctly, but not always as might be expected. Each time the servo speed is set, the time on the servo motion is reset. To experience accurate speed of the servo, don't set the servo speed more frequently than once per second.

