### PR TITLE
Corrected the conversion of linear and angular velocities to motor RPMs

### DIFF
--- a/config/roboquest_base.yaml
+++ b/config/roboquest_base.yaml
@@ -10,6 +10,5 @@
     min_rpm: 5
     max_rpm: 150
     rpm_to_tps: 1.25
-    track_circumference: 0.680
     track_separation: 0.225
-    sprocket_radius: 0.027
+    sprocket_radius: 0.0283

--- a/roboquest_core/rq_drive_utilities.py
+++ b/roboquest_core/rq_drive_utilities.py
@@ -14,30 +14,30 @@ class DriveUtils(object):
 
     def __init__(
         self,
-        sr: float,
-        tl: float,
-        ts: float
+        sprocket_radius: float,
+        track_separation: float
     ):
         """Initialize the constants.
 
-        sr is the radius of the drive sprocket in meters
-        tl is the length of the drive track in meters
-        ts is the distance between the centers of the two tracks,
+        sprocket_radius is the radius of the drive sprocket in meters,
+                        including the thickness of the track
+        track_separation is the distance between the centers of the two tracks,
            in meters
         """
-        scm = 2 * π * sr
-        AR = ts / 2
+
+        # scm is the sprocket circumference
+        scm = 2 * π * sprocket_radius
+        # AR is the angular motion radius
+        AR = track_separation / 2
 
         self._linear_conversion = (
             SECS_PER_MIN /
-            tl /
             scm
         )
 
         self._angular_conversion = (
             SECS_PER_MIN *
             AR /
-            tl /
             scm
         )
 

--- a/roboquest_core/rq_manage.py
+++ b/roboquest_core/rq_manage.py
@@ -115,7 +115,6 @@ class RQManage(RQNode):
         )
         self._drive_utils = DriveUtils(
             self._parameters['sprocket_radius'],
-            self._parameters['track_circumference'],
             self._parameters['track_separation']
         )
         self._gpio = UserGPIO()
@@ -402,7 +401,6 @@ class RQManage(RQNode):
             ('min_rpm', Parameter.Type.INTEGER),
             ('max_rpm', Parameter.Type.INTEGER),
             ('rpm_to_tps', Parameter.Type.DOUBLE),
-            ('track_circumference', Parameter.Type.DOUBLE),
             ('track_separation', Parameter.Type.DOUBLE),
             ('sprocket_radius', Parameter.Type.DOUBLE)
         ]


### PR DESCRIPTION
[rq_core Issue 95](https://github.com/billmania/roboquest_core/issues/95)

The conversion depends only upon three parameters now:

1. rpm_to_tps - multiply the desired RPM by this constant to get ticks per second
2. track_separation - the distance in meters between the centers of the two tracks, measured perpindicular to the long axis of the robot
3. sprocket_radius - the radius of the drive sprocket, in meters, including the added thickness of the track

This correction gives a maximum linear velocity of about 0.46 meters per second and a maximum angular velocity of about 0.39 radians per second.