### PR TITLE
Added output to HAT screen 4 while the updater.py script is starting

### DIFF
--- a/scripts/updater.py
+++ b/scripts/updater.py
@@ -35,7 +35,7 @@ from requests import get
 
 from rq_hat import RQHAT
 
-VERSION = '18rc1'
+VERSION = 18
 HAT_SERIAL = '/dev/ttyAMA1'
 SHUTDOWN_PIN = 27
 SERIAL_NUMBER_FILE = '/sys/firmware/devicetree/base/serial-number'
@@ -379,7 +379,7 @@ class RQUpdate(object):
             timeout=GET_TIMEOUT_S
         )
         if response.status_code == 200:
-            self._all_versions['latest']['updater'] = response.text[:-1]
+            self._all_versions['latest']['updater'] = int(response.text)
         else:
             logging.warning('No Internet connectivity')
             return False


### PR DESCRIPTION
The updater.py script will display the software version numbers and the robot's IP address, when it starts. If all goes well, this information will usually not remain on screen 4 long enough to be noticed by the student. However, when things start to go sideways, it will remain longer.

The key information looks like:

```
updater.py {VERSION}
c:##.# u:##.#
IP:###.###.###.###
```

This PR also includes some bug fixes for the robot shutdown procedure. Previously, the power button on the robot didn't perform a clean shutdown — it just pulled the plug. Now, all of "shutdown", "reboot", and the power button perform a clean shutdown.

See both [Shutdown](https://github.com/billmania/roboquest_core/wiki/Shutdown) and [Startup](https://github.com/billmania/roboquest_core/wiki/Startup) for more details