### PR TITLE
Add camera_info configuration files

### DIFF
--- a/config/arducam_1280x720_calibration.yaml
+++ b/config/arducam_1280x720_calibration.yaml
@@ -1,0 +1,26 @@
+image_width: 1280
+image_height: 720
+camera_name: ArducamUSBCamera_ArducamUSB__base_scb_pcie_7d500000_pci_0_0_usb_0_0_1_3_1_0_0c45_6366_1280x720
+camera_matrix:
+  rows: 3
+  cols: 3
+  data: [635.11259,   0.     , 670.8247 ,
+           0.     , 639.02461, 350.21039,
+           0.     ,   0.     ,   1.     ]
+distortion_model: plumb_bob
+distortion_coefficients:
+  rows: 1
+  cols: 5
+  data: [-0.294859, 0.058924, 0.000528, 0.000159, 0.000000]
+rectification_matrix:
+  rows: 3
+  cols: 3
+  data: [1., 0., 0.,
+         0., 1., 0.,
+         0., 0., 1.]
+projection_matrix:
+  rows: 3
+  cols: 4
+  data: [422.75839,   0.     , 654.75625,   0.     ,
+           0.     , 568.25439, 347.45489,   0.     ,
+           0.     ,   0.     ,   1.     ,   0.     ]

--- a/config/ov5647_1280x960_calibration.yaml
+++ b/config/ov5647_1280x960_calibration.yaml
@@ -1,0 +1,26 @@
+image_width: 1280
+image_height: 960
+camera_name: ov5647__base_soc_i2c0mux_i2c_1_ov5647_36_1280x960
+camera_matrix:
+  rows: 3
+  cols: 3
+  data: [784.65907,   0.     , 616.87995,
+           0.     , 782.37476, 439.16291,
+           0.     ,   0.     ,   1.     ]
+distortion_model: plumb_bob
+distortion_coefficients:
+  rows: 1
+  cols: 5
+  data: [-0.310424, 0.078961, -0.000554, -0.001429, 0.000000]
+rectification_matrix:
+  rows: 3
+  cols: 3
+  data: [1., 0., 0.,
+         0., 1., 0.,
+         0., 0., 1.]
+projection_matrix:
+  rows: 3
+  cols: 4
+  data: [579.43176,   0.     , 595.62477,   0.     ,
+           0.     , 670.27106, 422.90819,   0.     ,
+           0.     ,   0.     ,   1.     ,   0.     ]

--- a/config/ov5647_1280x960_calibration.yaml
+++ b/config/ov5647_1280x960_calibration.yaml
@@ -4,14 +4,14 @@ camera_name: ov5647__base_soc_i2c0mux_i2c_1_ov5647_36_1280x960
 camera_matrix:
   rows: 3
   cols: 3
-  data: [784.65907,   0.     , 616.87995,
-           0.     , 782.37476, 439.16291,
-           0.     ,   0.     ,   1.     ]
+  data: [4646.32307,    0.     ,  659.8242 ,
+            0.     , 3913.61813,  476.12906,
+            0.     ,    0.     ,    1.     ]
 distortion_model: plumb_bob
 distortion_coefficients:
   rows: 1
   cols: 5
-  data: [-0.310424, 0.078961, -0.000554, -0.001429, 0.000000]
+  data: [-5.516477, 60.654077, -0.185515, -0.123044, 0.000000]
 rectification_matrix:
   rows: 3
   cols: 3
@@ -21,6 +21,6 @@ rectification_matrix:
 projection_matrix:
   rows: 3
   cols: 4
-  data: [579.43176,   0.     , 595.62477,   0.     ,
-           0.     , 670.27106, 422.90819,   0.     ,
-           0.     ,   0.     ,   1.     ,   0.     ]
+  data: [4271.94482,    0.     ,  612.13556,    0.     ,
+            0.     , 3561.87988,  426.88879,    0.     ,
+            0.     ,    0.     ,    1.     ,    0.     ]

--- a/config/quickcampro9000.yaml
+++ b/config/quickcampro9000.yaml
@@ -1,0 +1,26 @@
+image_width: 1600
+image_height: 1200
+camera_name: UVCCamera_046d_0990___base_scb_pcie_7d500000_pci_0_0_usb_0_0_1_3_1_0_046d_0990_1600x1200.yaml
+camera_matrix:
+  rows: 3
+  cols: 3
+  data: [1562.52984,    0.     ,  745.44505,
+            0.     , 1569.10769,  620.81802,
+            0.     ,    0.     ,    1.     ]
+distortion_model: plumb_bob
+distortion_coefficients:
+  rows: 1
+  cols: 5
+  data: [-0.001720, -0.123874, 0.004809, -0.003152, 0.000000]
+rectification_matrix:
+  rows: 3
+  cols: 3
+  data: [1., 0., 0.,
+         0., 1., 0.,
+         0., 0., 1.]
+projection_matrix:
+  rows: 3
+  cols: 4
+  data: [1545.50146,    0.     ,  738.72844,    0.     ,
+            0.     , 1562.79993,  623.98029,    0.     ,
+            0.     ,    0.     ,    1.     ,    0.     ]

--- a/config/rq_camera0.yaml
+++ b/config/rq_camera0.yaml
@@ -1,8 +1,9 @@
 /**:
   ros__parameters:
     camera: 0
-    height: 480
-    width: 640
+    height: 960
+    width: 1280
+    format: 'YUYV'
     role: 'still'
     qos_overrides:
       /parameter_events:

--- a/config/rq_camera0.yaml
+++ b/config/rq_camera0.yaml
@@ -1,8 +1,8 @@
 /**:
   ros__parameters:
     camera: 0
-    height: 960
-    width: 1280
+    height: 1200
+    width: 1600
     format: 'YUYV'
     role: 'still'
     qos_overrides:

--- a/config/rq_camera_node0.yaml
+++ b/config/rq_camera_node0.yaml
@@ -1,6 +1,6 @@
-image_width: 640
-image_height: 480
-camera_name: ArducamUSBCamera_ArducamUSB__base_scb_pcie_7d500000_pci_0_0_usb_0_0_1_1_1_0_0c45_6366_640x480
+image_width: 1280
+image_height: 960
+camera_name: ArducamUSBCamera_ArducamUSB__base_scb_pcie_7d500000_pci_0_0_usb_0_0_1_1_1_0_0c45_6366_1280x960
 camera_matrix:
   rows: 3
   cols: 3

--- a/config/rq_camera_node0.yaml
+++ b/config/rq_camera_node0.yaml
@@ -1,0 +1,26 @@
+image_width: 640
+image_height: 480
+camera_name: ArducamUSBCamera_ArducamUSB__base_scb_pcie_7d500000_pci_0_0_usb_0_0_1_1_1_0_0c45_6366_640x480
+camera_matrix:
+  rows: 3
+  cols: 3
+  data: [1415.46001,    0.     ,  318.49754,
+            0.     , 1349.18889,  241.53498,
+            0.     ,    0.     ,    1.     ]
+distortion_model: plumb_bob
+distortion_coefficients:
+  rows: 1
+  cols: 5
+  data: [-1.831894, 8.113775, -0.061439, 0.078607, 0.000000]
+rectification_matrix:
+  rows: 3
+  cols: 3
+  data: [1., 0., 0.,
+         0., 1., 0.,
+         0., 0., 1.]
+projection_matrix:
+  rows: 3
+  cols: 4
+  data: [1296.02197,    0.     ,  341.73914,    0.     ,
+            0.     , 1277.72705,  231.04377,    0.     ,
+            0.     ,    0.     ,    1.     ,    0.     ]

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>roboquest_core</name>
-  <version>0.24.0</version>
+  <version>0.25.0</version>
   <description>ROS2 package for the RoboQuest backend</description>
   <maintainer email="bill@manialabs.us">Bill Mania</maintainer>
   <license>Proprietary</license>

--- a/roboquest_core/rq_manage.py
+++ b/roboquest_core/rq_manage.py
@@ -42,7 +42,7 @@ from rq_msgs.srv import Control
 
 from std_srvs.srv import Empty
 
-VERSION = '24.1'
+VERSION = '25'
 
 MODULE_DIR = (
     '/usr/src/ros2ws'

--- a/roboquest_core/servo_tester.py
+++ b/roboquest_core/servo_tester.py
@@ -29,7 +29,7 @@ from rq_msgs.msg import Servos
 from rq_msgs.srv import Control
 
 
-VERSION = '24.1rc5'
+VERSION = '25'
 
 MODULE_DIR = (
     '/usr/src/ros2ws'

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ package_name = 'roboquest_core'
 
 setup(
     name=package_name,
-    version='0.24.0',
+    version='0.25.0',
     packages=[package_name],
     data_files=[
         ('share/ament_index/resource_index/packages',


### PR DESCRIPTION
Added configuration files for three cameras, in order to use them as camera_info input for detecting and analyzing APRIL tags.

- ov5647 CSI ribbon cable fisheye camera
- ArduCam USB fisheye camera
- Logitech QuickCam Pro 900 USB camera