### PR TITLE
Backup and restore utilities for Roboquest configuration files

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+#
+# Create an archive of the Roboquest configuration files and then
+# POST them to the backup location of the backup server.
+#
+
+TMP_DIR="/tmp"
+PERSIST_DIR="/opt/persist"
+BACKUP_URL="https://registry.q4excellence.com:5678/backup"
+SERIAL_NUMBER_FILE="/sys/firmware/devicetree/base/serial-number"
+FILES_TO_BACKUP="ui/ros_interfaces.js ui/widget_interface.js nodes/user_nodes.launch.py configuration.json servos_config.json i2c/i2c.yaml"
+
+get_serial ()
+{
+    cat $SERIAL_NUMBER_FILE
+}
+
+name_tar_file ()
+{
+    local serial
+    serial=$(get_serial)
+
+    TAR_FILE=${serial}_config
+
+    echo "${TAR_FILE}"
+}
+
+collect_files ()
+{
+    cd $PERSIST_DIR || return
+    tar czf "${TMP_DIR}/$1.tgz" ${FILES_TO_BACKUP}
+}
+
+save_files ()
+{
+    curl -l -H 'Content-type: application/gzip' --data-binary "@${TMP_DIR}/$1.tgz" ${BACKUP_URL}?$1
+}
+
+tar_file=$(name_tar_file)
+collect_files "$tar_file"
+save_files "$tar_file"
+
+exit 0
+

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -29,12 +29,12 @@ name_tar_file ()
 collect_files ()
 {
     cd $PERSIST_DIR || return
-    tar czf "${TMP_DIR}/$1.tgz" ${FILES_TO_BACKUP}
+    tar --ignore-failed-read --create --gzip --file "${TMP_DIR}/$1.tgz" ${FILES_TO_BACKUP}
 }
 
 save_files ()
 {
-    curl -l -H 'Content-type: application/gzip' --data-binary "@${TMP_DIR}/$1.tgz" ${BACKUP_URL}?$1
+    curl -H 'Content-type: application/x-gtar-compressed' --data-binary "@${TMP_DIR}/$1.tgz" "${BACKUP_URL}?$1"
 }
 
 tar_file=$(name_tar_file)

--- a/scripts/lighttpd.conf
+++ b/scripts/lighttpd.conf
@@ -6,15 +6,29 @@ server.modules = (
   "mod_setenv",
   "mod_redirect",
   "mod_proxy",
+  "mod_fastcgi"
 )
 
 server.document-root = "/var/www/html"
 server.errorlog      = "/var/log/lighttpd/error.log"
 accesslog.filename   = "/var/log/lighttpd/access.log"
+accesslog.format     = "%t %h %r %s \"%{User-Agent}i\""
 server.pid-file      = "/run/lighttpd.pid"
 server.username      = "www-data"
 server.groupname     = "www-data"
 server.port          = 8079
+
+fastcgi.debug = 1
+fastcgi.server = (
+    ".py" => (
+        "python-fcgi" => (
+            "socket" => "/tmp/" + "fastcgi.python.socket",
+	    "bin-path" => "/var/www/backups/python-fcgi",
+	    "max-procs" => 1,
+            "check-local" => "disable"
+        )
+    )
+)
 
 $HTTP["scheme"] == "http" {
     $HTTP["host"] =~ "^(.*?)(:\d+)?$" {  ## %1 contains hostname without port

--- a/scripts/lighttpd.conf
+++ b/scripts/lighttpd.conf
@@ -18,12 +18,12 @@ server.username      = "www-data"
 server.groupname     = "www-data"
 server.port          = 8079
 
-fastcgi.debug = 1
+fastcgi.debug = 0
 fastcgi.server = (
-    ".py" => (
+    "/backup" => (
         "python-fcgi" => (
-            "socket" => "/tmp/" + "fastcgi.python.socket",
-	    "bin-path" => "/var/www/backups/python-fcgi",
+            "socket" => "/var/www/run/" + "fastcgi.python.socket",
+	    "bin-path" => "/var/www/cgi/python-fcgi",
 	    "max-procs" => 1,
             "check-local" => "disable"
         )

--- a/scripts/python-fcgi
+++ b/scripts/python-fcgi
@@ -1,7 +1,27 @@
 #!/usr/bin/env python3
 """WSGI server for backup and restore of configuration."""
 
+from pathlib import Path
+from time import sleep
+
 from flup.server.fcgi import WSGIServer
+
+
+BACKUP_DIR = Path('/var/www/backups')
+LOG_DIR = '/var/www/cgi'
+
+
+def save_data(file_name, file_content) -> None:
+    """Save the file contents.
+
+    Disable any malicious-ness in file_name and then save
+    file_content in a file named file_name.
+    """
+    # TODO: Clean file_name
+    full_path = BACKUP_DIR / file_name
+    full_path.unlink(missing_ok=True)
+    with open(full_path, mode='wb') as file:
+        file.write(file_content)
 
 
 def application(environ, start_response):
@@ -10,6 +30,9 @@ def application(environ, start_response):
         int(environ.get('CONTENT_LENGTH', 0))
         if environ.get('CONTENT_LENGTH')
         else 0
+    )
+    query_string = (
+        environ.get('QUERY_STRING', None)
     )
 
     post_data = (
@@ -23,23 +46,40 @@ def application(environ, start_response):
     else:
         data = post_data.decode('utf-8')
 
-    status = '200 OK'
-    headers = [('Content-type', 'text/html')]
-    start_response(status, headers)
+    try:
+        save_data(query_string, data)
 
-    response_body = (
-        '<html><body>\n'
-        '<h1>POST query_string:</h1><pre>'
-        f'{environ.get("QUERY_STRING", "")}</pre>\n'
-        '<h1>POST content_type:</h1><pre>'
-        f'{environ.get("CONTENT_TYPE", "")}</pre>\n'
-        '<h1>POST length:</h1><pre>'
-        f'{environ.get("CONTENT_LENGTH")}</pre>\n'
-        '</body></html>\n'
-    )
+    except Exception:
+        # TODO: Correct the status to something in the 400 series
+        status = '200 OK'
+        headers = [('Content-type', 'text/html')]
+        start_response(status, headers)
+        response_body = ''
+
+    else:
+        status = '200 OK'
+        headers = [('Content-type', 'text/html')]
+        start_response(status, headers)
+
+        response_body = (
+            '<html><body>\n'
+            '<h1>POST query_string:</h1><pre>'
+            f'{environ.get("QUERY_STRING", "")}</pre>\n'
+            '<h1>POST content_type:</h1><pre>'
+            f'{environ.get("CONTENT_TYPE", "")}</pre>\n'
+            '<h1>POST length:</h1><pre>'
+            f'{environ.get("CONTENT_LENGTH")}</pre>\n'
+            '</body></html>\n'
+        )
 
     return [response_body.encode('utf-8')]
 
 
 if __name__ == '__main__':
-    WSGIServer(application).run()
+    max_tries = 10
+    while max_tries:
+        try:
+            WSGIServer(application).run()
+        except Exception:
+            max_tries -= 1
+            sleep(30.0)

--- a/scripts/python-fcgi
+++ b/scripts/python-fcgi
@@ -17,8 +17,12 @@ def save_data(file_name, file_content) -> None:
     Disable any malicious-ness in file_name and then save
     file_content in a file named file_name.
     """
-    # TODO: Clean file_name
-    full_path = BACKUP_DIR / file_name
+    last_slash_index = file_name.rfind('/')
+    if last_slash_index > -1:
+        clean_file_name = file_name[last_slash_index+1:]
+    else:
+        clean_file_name = file_name
+    full_path = BACKUP_DIR / clean_file_name
     full_path.unlink(missing_ok=True)
     with open(full_path, mode='wb') as file:
         file.write(file_content)
@@ -50,14 +54,13 @@ def application(environ, start_response):
         save_data(query_string, data)
 
     except Exception:
-        # TODO: Correct the status to something in the 400 series
-        status = '200 OK'
+        status = '500 '
         headers = [('Content-type', 'text/html')]
         start_response(status, headers)
         response_body = ''
 
     else:
-        status = '200 OK'
+        status = '200 '
         headers = [('Content-type', 'text/html')]
         start_response(status, headers)
 

--- a/scripts/python-fcgi
+++ b/scripts/python-fcgi
@@ -7,8 +7,7 @@ from time import sleep
 from flup.server.fcgi import WSGIServer
 
 
-BACKUP_DIR = Path('/var/www/backups')
-LOG_DIR = '/var/www/cgi'
+BACKUP_DIR = Path('/var/www/html/archives')
 
 
 def save_data(file_name, file_content) -> None:
@@ -45,10 +44,17 @@ def application(environ, start_response):
         else b''
     )
 
-    if environ.get('CONTENT_TYPE', '').startswith('application/gzip'):
+    if environ.get('CONTENT_TYPE', '').startswith(
+        'application/x-gtar-compressed'
+    ):
         data = post_data
     else:
-        data = post_data.decode('utf-8')
+        status = '400 '
+        headers = [('Content-type', 'text/html')]
+        start_response(status, headers)
+        response_body = 'Content-type must be application/x-gtar-compressed'
+
+        return [response_body.encode('utf-8')]
 
     try:
         save_data(query_string, data)

--- a/scripts/python-fcgi
+++ b/scripts/python-fcgi
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""WSGI server for backup and restore of configuration."""
+
+from flup.server.fcgi import WSGIServer
+
+
+def application(environ, start_response):
+    """Process the received data."""
+    content_length = (
+        int(environ.get('CONTENT_LENGTH', 0))
+        if environ.get('CONTENT_LENGTH')
+        else 0
+    )
+
+    post_data = (
+        environ['wsgi.input'].read(content_length)
+        if content_length
+        else b''
+    )
+
+    if environ.get('CONTENT_TYPE', '').startswith('application/gzip'):
+        data = post_data
+    else:
+        data = post_data.decode('utf-8')
+
+    status = '200 OK'
+    headers = [('Content-type', 'text/html')]
+    start_response(status, headers)
+
+    response_body = (
+        '<html><body>\n'
+        '<h1>POST query_string:</h1><pre>'
+        f'{environ.get("QUERY_STRING", "")}</pre>\n'
+        '<h1>POST content_type:</h1><pre>'
+        f'{environ.get("CONTENT_TYPE", "")}</pre>\n'
+        '<h1>POST length:</h1><pre>'
+        f'{environ.get("CONTENT_LENGTH")}</pre>\n'
+        '</body></html>\n'
+    )
+
+    return [response_body.encode('utf-8')]
+
+
+if __name__ == '__main__':
+    WSGIServer(application).run()

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+#
+# Retrieve an archive of the Roboquest configuration files
+# using a GET from the back location. Restore the files
+# to the robot's filesystem.
+#
+
+TMP_DIR="/tmp"
+PERSIST_DIR="/opt/persist"
+RESTORE_URL="https://registry.q4excellence.com:5678/archives"
+SERIAL_NUMBER_FILE="/sys/firmware/devicetree/base/serial-number"
+
+get_serial ()
+{
+    cat $SERIAL_NUMBER_FILE
+}
+
+name_tar_file ()
+{
+    TAR_FILE=$(get_serial)_config.tgz
+    echo "${TAR_FILE}"
+}
+
+retrieve_files ()
+{
+    curl -X GET --output "$1" "${RESTORE_URL}/$1" 
+}
+
+extract_files ()
+{
+    cd $PERSIST_DIR || return
+    tar xzf "${TMP_DIR}/$1"
+}
+
+tar_file=$(name_tar_file)
+retrieve_files "$tar_file"
+extract_files "$tar_file"
+
+exit 0

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -16,25 +16,25 @@ get_serial ()
     cat $SERIAL_NUMBER_FILE
 }
 
-name_tar_file ()
+name_archive_file ()
 {
-    TAR_FILE=$(get_serial)_config.tgz
+    TAR_FILE=$(get_serial)_config
     echo "${TAR_FILE}"
 }
 
 retrieve_files ()
 {
-    curl -X GET --output "$1" "${RESTORE_URL}/$1" 
+    curl -X GET --output "${TMP_DIR}/$1.tgz" "${RESTORE_URL}/$1" 
 }
 
 extract_files ()
 {
     cd $PERSIST_DIR || return
-    tar xzf "${TMP_DIR}/$1"
+    tar xzf "${TMP_DIR}/$1.tgz"
 }
 
-tar_file=$(name_tar_file)
-retrieve_files "$tar_file"
-extract_files "$tar_file"
+archive_file=$(name_archive_file)
+retrieve_files "$archive_file"
+extract_files "$archive_file"
 
 exit 0


### PR DESCRIPTION
The two tools require:

  - the robot Raspberry Pi is functional
  - its filesystem is not corrupt
  - the robot is connected to the public Internet
  - the user can ssh to the robot OS

The user configuration files are bundled into a compressed tar archive and transferred to the remote location. The backup set is identified by the serial number of the Raspberry Pi.
Each time the backup is made it overwrites any previous backup which may exist. When the files are restored to the robot from the backup, any existing configuration file is automatically replaced with the version from the backup. Any configuration file missing from the robot when the backup is created, will be silently ignored by the backup utility, ie. the backup and restore utilities can't do anything about a file which is already missing before the backup is made.

The user configuration files included in the backup, as of rq_core v25, are:

  - /opt/persist/ui/ros_interfaces.js
  -  /opt/persist/ui/widget_interface.js
  - /opt/persist/nodes/user_nodes.launch.py
  - /opt/persist/configuration.json
  - /opt/persist/servos_config.json
  - /opt/persist/i2c/i2c.yaml

In order to use these utilities, either ssh to the robot over the network or connect via the serial console.

To backup the configuration files, execute:
```
sudo /usr/local/bin/backup.sh
```

and to restore the files from backup:
```
sudo /usr/local/bin/restore.sh
```
