### PR TITLE
Create the ManageFiles class so updater.py can manage files on the robot

### DIFF
--- a/scripts/manage_files.py
+++ b/scripts/manage_files.py
@@ -1,0 +1,101 @@
+"""Manage files.
+
+A utility class to handle the installation and removal of files
+on the robot's base OS.
+"""
+
+from json import loads as jloads
+from typing import Callable
+
+from requests import get
+
+
+CONFIG_FILE_URL = 'https://registry.q4excellence.com:5678/manage_files.json'
+GET_TIMEOUT_S = 5.0
+
+
+class ManageFiles(object):
+    """Manage file installation and removal."""
+
+    def __init__(self, logger: Callable):
+        """Prepare to manage files."""
+        if logger:
+            self._log_debug = logger.debug
+            self._log_info = logger.info
+            self._log_warning = logger.warning
+            self._log_error = logger.error
+        else:
+            self._log_debug = print
+            self._log_info = print
+            self._log_warning = print
+            self._log_error = print
+
+    def _parse_config_file(self, raw_config_file) -> None:
+        """Parse the contents of the config file."""
+        try:
+            self._file_config = jloads(raw_config_file)
+        except Exception as e:
+            self._log_error(
+                f'Failed to parse {raw_config_file}'
+                f' : {e}'
+            )
+
+        self._log_debug(
+            f"config file parsed installs: {self._file_config['install']}"
+        )
+        self._log_debug(
+            f"config file parsed removes: {self._file_config['remove']}"
+        )
+
+    def get_config_file(self) -> None:
+        """Get the configuration file.
+
+        Retrieve the file management configuration file from
+        the registry and parse it into a Python object.
+        """
+        try:
+            config_file_content = get(
+                CONFIG_FILE_URL,
+                timeout=GET_TIMEOUT_S
+            )
+            if config_file_content.status_code == 200:
+                self._log_debug(
+                    'config file raw content:'
+                    f' {config_file_content.text}'
+                )
+            else:
+                self._log_error(
+                    'config file content status:'
+                    f' {config_file_content.status_code}'
+                )
+
+        except Exception as e:
+            self._log_error(
+                'Exception getting file management config file'
+                f' {CONFIG_FILE_URL}'
+                f' : {e}'
+            )
+            self._config_file = None
+
+        self._parse_config_file(config_file_content.text)
+
+    def remove_files(self) -> None:
+        """Remove files.
+
+        Use the file management object to get the list of files
+        to remove. Remove those files.
+        """
+        pass
+
+    def install_files(self) -> None:
+        """Install files.
+
+        Use the file management object to get the list of files
+        to be installed. Install those files.
+        """
+        pass
+
+
+if __name__ == '__main__':
+    MF = ManageFiles(None)
+    MF.get_config_file()

--- a/scripts/manage_files.py
+++ b/scripts/manage_files.py
@@ -4,48 +4,50 @@ A utility class to handle the installation and removal of files
 on the robot's base OS.
 """
 
+from grp import getgrnam
+from hashlib import md5
 from json import loads as jloads
+from os import chown
+from pathlib import Path
+from pwd import getpwnam
 from typing import Callable
 
 from requests import get
 
 
-CONFIG_FILE_URL = 'https://registry.q4excellence.com:5678/manage_files.json'
+BASE_URL = 'https://registry.q4excellence.com:5678/'
+CONFIG_FILE_URL = BASE_URL + 'manage_files.json'
+BASE_FILE_URL = BASE_URL + 'files/'
 GET_TIMEOUT_S = 5.0
 
 
 class ManageFiles(object):
     """Manage file installation and removal."""
 
-    def __init__(self, logger: Callable):
+    def __init__(self, logging: Callable):
         """Prepare to manage files."""
-        if logger:
-            self._log_debug = logger.debug
-            self._log_info = logger.info
-            self._log_warning = logger.warning
-            self._log_error = logger.error
+        if logging:
+            self._log_info = logging.info
+            self._log_warning = logging.warning
+            self._log_error = logging.error
         else:
-            self._log_debug = print
             self._log_info = print
             self._log_warning = print
             self._log_error = print
 
-    def _parse_config_file(self, raw_config_file) -> None:
+    def _parse_config_file(self, raw_config_file) -> dict:
         """Parse the contents of the config file."""
         try:
-            self._file_config = jloads(raw_config_file)
+            file_config = jloads(raw_config_file)
+
         except Exception as e:
             self._log_error(
                 f'Failed to parse {raw_config_file}'
                 f' : {e}'
             )
+            file_config = None
 
-        self._log_debug(
-            f"config file parsed installs: {self._file_config['install']}"
-        )
-        self._log_debug(
-            f"config file parsed removes: {self._file_config['remove']}"
-        )
+        return file_config
 
     def get_config_file(self) -> None:
         """Get the configuration file.
@@ -58,12 +60,7 @@ class ManageFiles(object):
                 CONFIG_FILE_URL,
                 timeout=GET_TIMEOUT_S
             )
-            if config_file_content.status_code == 200:
-                self._log_debug(
-                    'config file raw content:'
-                    f' {config_file_content.text}'
-                )
-            else:
+            if config_file_content.status_code != 200:
                 self._log_error(
                     'config file content status:'
                     f' {config_file_content.status_code}'
@@ -77,7 +74,10 @@ class ManageFiles(object):
             )
             self._config_file = None
 
-        self._parse_config_file(config_file_content.text)
+        else:
+            self._config_file = self._parse_config_file(
+                config_file_content.text
+            )
 
     def remove_files(self) -> None:
         """Remove files.
@@ -85,7 +85,78 @@ class ManageFiles(object):
         Use the file management object to get the list of files
         to remove. Remove those files.
         """
-        pass
+        for file in self._config_file['remove']:
+            continue
+
+    def _file_changed(self, full_path, md5sum) -> bool:
+        """Check the state of the file.
+
+        If it doesn't exist, return True.
+        If it exists but doesn't match the md5sum of the source
+        file, return True.
+        Otherwise return False.
+        """
+        if Path(full_path).exists():
+            try:
+                hasher = md5()
+                with open(full_path, 'rb') as f:
+                    hasher.update(f.read())
+                local_digest = hasher.hexdigest()
+            except Exception as e:
+                self._log_warning(
+                    f'Failed on hash: {e}'
+                )
+                return True
+
+            if local_digest == md5sum:
+                return False
+
+        return True
+
+    def _retrieve_file(self, source_file) -> str:
+        """Retrieve the source file contents."""
+        try:
+            config_file_content = get(
+                BASE_FILE_URL+source_file,
+                timeout=GET_TIMEOUT_S
+            )
+            if config_file_content.status_code == 200:
+                return config_file_content.text
+                self._log_error(
+                    'config file content status:'
+                    f' {config_file_content.status_code}'
+                )
+
+        except Exception as e:
+            self._log_warning(
+                f'Failed to retrieve source file {source_file}'
+                f' Exception: {e}'
+            )
+            return None
+
+    def _install_file(self, file_content, file_details) -> None:
+        """Install an individual file.
+
+        Install file_content into the full path and set
+        the owner, group, and mode.
+        """
+        full_path = Path(file_details['full_path'])
+        full_path.unlink(missing_ok=True)
+        try:
+            full_path.touch(mode=file_details['mode'])
+            with open(full_path, 'w') as f:
+                f.write(file_content)
+
+            chown(
+                full_path,
+                getpwnam(file_details['owner']).pw_uid,
+                getgrnam(file_details['group']).gr_gid
+            )
+        except Exception as e:
+            self._log_warning(
+                f"Failed to install {file_details['full_path']}"
+                f' Exception: {e}'
+            )
 
     def install_files(self) -> None:
         """Install files.
@@ -93,9 +164,31 @@ class ManageFiles(object):
         Use the file management object to get the list of files
         to be installed. Install those files.
         """
-        pass
+        for file in self._config_file['install']:
+            try:
+                if self._file_changed(
+                    file['details']['full_path'],
+                    file['md5sum']
+                ):
+                    file_content = self._retrieve_file(file['source'])
+                    if file_content:
+                        self._log_info(
+                            f"Installing: {file['details']['full_path']}"
+                        )
+                        self._install_file(
+                            file_content,
+                            file['details']
+                        )
+
+            except Exception as e:
+                self._log_warning(
+                    f"Exception installing: {file['details']['full_path']}"
+                    f' : {e}'
+                )
 
 
 if __name__ == '__main__':
     MF = ManageFiles(None)
     MF.get_config_file()
+    MF.install_files()
+    MF.remove_files()

--- a/scripts/manage_files.py
+++ b/scripts/manage_files.py
@@ -10,7 +10,7 @@ from json import loads as jloads
 from os import chown
 from pathlib import Path
 from pwd import getpwnam
-from typing import Callable
+from types import ModuleType
 
 from requests import get
 
@@ -24,7 +24,7 @@ GET_TIMEOUT_S = 5.0
 class ManageFiles(object):
     """Manage file installation and removal."""
 
-    def __init__(self, logging: Callable):
+    def __init__(self, logging: ModuleType = None):
         """Prepare to manage files."""
         if logging:
             self._log_info = logging.info


### PR DESCRIPTION
The ManageFiles class is used by updater.py to install files on the robot, to update files to newer versions, to replace corrupted files, and to remove files. If the file to be removed from the robot has been modified since installation, it won't be removed from the robot unless the "force" attribute is set.

It's controlled by a configuration file hosted on the registry server, with the following example content:
```
{
  "install": [
    {
      "source": "backup.sh",
      "md5sum": "48824a0bd38bce720d6c6188d85d7f32",
      "details": {
        "full_path": "/usr/local/bin/backup.sh",
        "owner": "root",
        "group": "root",
        "mode": "0550"
      }
    },
    {
      "source": "restore.sh",
      "md5sum": "d94ad0f8f4282192faa6f11b55e9b476",
      "details": {
        "full_path": "/usr/local/bin/restore.sh",
        "owner": "root",
        "group": "root",
        "mode": "0550"
      }
    }
  ],

  "remove": [
    {
      "full_path": "/tmp/test",
      "md5sum": "48824a0bd38bce720d6c6188d85d7f32",
      "force": true
    }
  ]
}
```

The files are placed on the registry server in /var/www/html/files. The configuration file is /var/www/html/manage_files.json.

This functionality has the desired side-effect of installing the new backup.sh and restore.sh command line utilities, from [rq_core PR 109](https://github.com/billmania/roboquest_core/pull/109).