### PR TITLE
Add a utility for registering a robot

### DIFF
--- a/scripts/manage_files.json
+++ b/scripts/manage_files.json
@@ -1,0 +1,62 @@
+{
+  "install": [
+    {
+      "source": "cert.pem",
+      "md5sum": "5b84aa5aece7d25605f1b069f2b8958b",
+      "details": {
+        "full_path": "/opt/updater/cert.pem",
+        "owner": "root",
+        "group": "root",
+        "mode": 288
+      }
+    },
+    {
+      "source": "key.pem",
+      "md5sum": "888c938240def0a3590107bf86dd5cf8",
+      "details": {
+        "full_path": "/opt/updater/key.pem",
+        "owner": "root",
+        "group": "root",
+        "mode": 288
+      }
+    },
+    {
+      "source": "register.sh",
+      "md5sum": "bd7a9e1d897a007585067caa1ac350d6",
+      "details": {
+        "full_path": "/usr/local/bin/register.sh",
+        "owner": "root",
+        "group": "root",
+        "mode": 360
+      }
+    },
+    {
+      "source": "backup.sh",
+      "md5sum": "48824a0bd38bce720d6c6188d85d7f32",
+      "details": {
+        "full_path": "/usr/local/bin/backup.sh",
+        "owner": "root",
+        "group": "root",
+        "mode": 360
+      }
+    },
+    {
+      "source": "restore.sh",
+      "md5sum": "d94ad0f8f4282192faa6f11b55e9b476",
+      "details": {
+        "full_path": "/usr/local/bin/restore.sh",
+        "owner": "root",
+        "group": "root",
+        "mode": 360
+      }
+    }
+  ],
+
+  "remove": [
+    {
+      "full_path": "/tmp/test",
+      "md5sum": "48824a0bd38bce720d6c6188d85d7f32",
+      "force": true
+    }
+  ]
+}

--- a/scripts/manage_files.json
+++ b/scripts/manage_files.json
@@ -22,7 +22,7 @@
     },
     {
       "source": "register.sh",
-      "md5sum": "bd7a9e1d897a007585067caa1ac350d6",
+      "md5sum": "e7dbec898b8aa72b5a2bf205bc245c92",
       "details": {
         "full_path": "/usr/local/bin/register.sh",
         "owner": "root",

--- a/scripts/register.sh
+++ b/scripts/register.sh
@@ -9,7 +9,7 @@ REGISTER_URL="https://registry.q4excellence.com:5678/register"
 
 get_serial ()
 {
-    cat $SERIAL_NUMBER_FILE
+    sed -e 's/\x00$//' < $SERIAL_NUMBER_FILE
 }
 
 get_user_name ()
@@ -22,8 +22,10 @@ register_robot ()
         curl ${REGISTER_URL}?serial="$1"\&user="$2"
 }
 
-raw_user_name=$1
+user_name=$(get_user_name "$1")
+serial_number=$(get_serial)
+register_robot "${serial_number}" "${user_name}"
 
-register_robot $(get_serial) $(get_user_name "${raw_user_name}")
+echo "Registered user ${user_name}"
 
 exit 0

--- a/scripts/register.sh
+++ b/scripts/register.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+#
+# Associate a user name with the robot's serial number. 
+#
+
+SERIAL_NUMBER_FILE="/sys/firmware/devicetree/base/serial-number"
+REGISTER_URL="https://registry.q4excellence.com:5678/register"
+
+get_serial ()
+{
+    cat $SERIAL_NUMBER_FILE
+}
+
+get_user_name ()
+{
+    echo "$1" | sed -e 's/[^a-zA-Z0-9]//g' -e 's/^\(.........................\).*$/\1/'
+}
+
+register_robot ()
+{
+        curl ${REGISTER_URL}?serial="$1"\&user="$2"
+}
+
+raw_user_name=$1
+
+register_robot $(get_serial) $(get_user_name "${raw_user_name}")
+
+exit 0


### PR DESCRIPTION
Similar to backup.sh and restore.sh, the command line utility **register.sh** is used after connecting to the robot's base OS using ssh.

To use it:
```
sudo /usr/local/bin/register.sh <MyUserName>
```

The actual user name recorded is formed by extracting the first 25 characters from \<MyUserName\> which match the regex [a-zA-Z0-9]. If \<MyUserName\> contains any SPACE characters, enclose the whole thing in quotation marks, but the SPACEs will still be ignored.