### PR TITLE
Updated rq_hat.py and updater.py to use modern GPIO control

### DIFF
--- a/roboquest_core/rq_gpio_utils.py
+++ b/roboquest_core/rq_gpio_utils.py
@@ -64,9 +64,27 @@ def set_pin(pin_name: RQ_GPIO = None, pin_state: str = None) -> str:
     return pin_state
 
 
-def get_pin(pin: RQ_GPIO = None) -> str:
+def get_pin(pin_name: RQ_GPIO = None) -> str:
     """Read the state of a pin."""
-    return 'Not implemented'
+    if pin_name:
+        pin = pin_name.value
+    else:
+        return None
+
+    with gpiod.request_lines(
+        GPIO_DEVICE,
+        consumer='rq_gpio_utils',
+        config={
+            pin: gpiod.LineSettings(
+                direction=Direction.INPUT
+            )
+        },
+    ) as request:
+        return (
+            'high'
+            if request.get_value(pin) == Value.ACTIVE
+            else 'low'
+        )
 
 
 def detect_change(pin: RQ_GPIO = None, change: str = None):

--- a/roboquest_core/rq_gpio_utils.py
+++ b/roboquest_core/rq_gpio_utils.py
@@ -1,0 +1,132 @@
+"""gpio utility functions.
+
+Utility functions and constants for manipulating and
+monitoring GPIO pins.
+"""
+
+from enum import Enum
+
+import gpiod
+from gpiod.line import Direction, Value
+
+
+GPIO_DEVICE = '/dev/gpiochip0'
+
+
+class RQ_GPIO(Enum):
+    """Pins used by the Roboquest application."""
+
+    COMMS_ENABLE = 'GPIO22'
+    FET_1_ENABLE = 'GPIO24'
+    FET_2_ENABLE = 'GPIO25'
+    CHARGE_BATTERY = 'GPIO21'
+    CHARGER_POWERED = 'GPIO7'
+
+
+def check_device():
+    """Get information about a GPIO device."""
+    is_gpio_device = gpiod.is_gpiochip_device(GPIO_DEVICE)
+    if is_gpio_device:
+        print(
+            f'{GPIO_DEVICE} is an actual GPIO device'
+        )
+
+        with gpiod.Chip(GPIO_DEVICE) as chip:
+            info = chip.get_info()
+            print(
+                f'{info.name} [{info.label}] ({info.num_lines} lines)'
+            )
+
+
+def set_pin(pin_name: RQ_GPIO = None, pin_state: str = None) -> str:
+    """Set the state of a pin."""
+    if pin_name:
+        pin = pin_name.value
+    else:
+        return None
+
+    if pin_state in ['on', 'active', 'high', '1']:
+        pin_value = Value.ACTIVE
+    else:
+        pin_value = Value.INACTIVE
+    with gpiod.request_lines(
+        GPIO_DEVICE,
+        consumer='rq_gpio_utils',
+        config={
+            pin: gpiod.LineSettings(
+                direction=Direction.OUTPUT,
+                output_value=pin_value
+            )
+        },
+    ) as request:
+        request.set_value(pin, pin_value)
+
+    return pin_state
+
+
+def get_pin(pin: RQ_GPIO = None) -> str:
+    """Read the state of a pin."""
+    return 'Not implemented'
+
+
+def detect_change(pin: RQ_GPIO = None, change: str = None):
+    """Watch for a specific state change on a pin."""
+    pass
+
+
+if __name__ == '__main__':
+    import argparse
+
+    def _parse_args() -> argparse.Namespace:
+        """Get the arguments from the command line."""
+        parser = argparse.ArgumentParser(
+            prog='gpio_utils',
+            description='Use the rq_gpio_utils functions',
+            epilog=''
+        )
+
+        parser.add_argument(
+            '--check_device',
+            dest='check_device',
+            action='store_true',
+            help='Check the GPIO device'
+        )
+        parser.add_argument(
+            '--pin_name',
+            dest='pin_name',
+            default=None,
+            help='Name of the pin to control',
+            type=str
+        )
+        parser.add_argument(
+            '--pin_value',
+            dest='pin_value',
+            default=None,
+            help='Set the pin value',
+            type=str
+        )
+
+        return parser.parse_args()
+
+    parsed_args = _parse_args()
+
+    if parsed_args.check_device:
+        check_device()
+
+    if parsed_args.pin_name:
+        try:
+            pin = RQ_GPIO[parsed_args.pin_name]
+
+        except KeyError:
+            raise Exception(
+                f'{parsed_args.pin_name} is not known'
+            )
+
+        if parsed_args.pin_value:
+            print(
+                f'Set {pin.value}: {set_pin(pin, parsed_args.pin_value)}'
+            )
+        else:
+            print(
+                f'Get {pin.value}: {get_pin(pin)}'
+            )

--- a/roboquest_core/rq_gpio_utils.py
+++ b/roboquest_core/rq_gpio_utils.py
@@ -4,13 +4,20 @@ Utility functions and constants for manipulating and
 monitoring GPIO pins.
 """
 
+import threading
+from datetime import timedelta
 from enum import Enum
+from sys import exit as sys_exit
+from typing import Callable
+
 
 import gpiod
-from gpiod.line import Direction, Value
+from gpiod.line import Bias, Direction, Edge, Value
 
 
 GPIO_DEVICE = '/dev/gpiochip0'
+
+detector = None
 
 
 class RQ_GPIO(Enum):
@@ -21,6 +28,75 @@ class RQ_GPIO(Enum):
     FET_2_ENABLE = 'GPIO25'
     CHARGE_BATTERY = 'GPIO21'
     CHARGER_POWERED = 'GPIO7'
+    SHUTDOWN = 'GPIO27'
+
+
+class GPIOEdgeDetector:
+    """Detect a rising edge.
+
+    Watches pin_name for a rising-edge transition.
+    This class uses a threading.Thread to busy-loop check
+    the state of the pin. When the rising edge is detected,
+    the callback function is called. If the callback returns,
+    the thread will exit.
+    """
+
+    def __init__(
+        self,
+        pin_name: RQ_GPIO = None,
+        callback: Callable[[gpiod.EdgeEvent], None] = None,
+        bias: Bias = Bias.AS_IS,
+        debounce_us: int = 0
+    ):
+        """Create the detector."""
+        if pin_name and callback:
+            self._pin = pin_name.value
+        else:
+            return None
+
+        self._callback = callback
+        self._stop_event = threading.Event()
+        self.done = False
+
+        self._request = gpiod.request_lines(
+            GPIO_DEVICE,
+            consumer='rq_gpio_utils',
+            config={
+                self._pin: gpiod.LineSettings(
+                    direction=Direction.INPUT,
+                    edge_detection=Edge.RISING,
+                    bias=bias,
+                    debounce_period=timedelta(microseconds=debounce_us)
+                )
+            },
+        )
+        self._offset = self._request.offsets[0]
+
+        self._thread = threading.Thread(target=self._watch_loop, daemon=True)
+
+    def start(self) -> None:
+        """Start the detector thread."""
+        self._thread.start()
+
+    def stop(self) -> None:
+        """Stop the detector thread."""
+        self._stop_event.set()
+        self._thread.join()
+        self._request.release()
+
+    def _watch_loop(self) -> None:
+        while not self._stop_event.is_set():
+            #
+            # Poll with a timeout so the stop flag gets checked periodically
+            # rather than blocking forever on wait_edge_events().
+            #
+            if self._request.wait_edge_events(
+                timeout=timedelta(milliseconds=200)
+            ):
+                for event in self._request.read_edge_events():
+                    if event.line_offset == self._offset:
+                        self._callback(event)
+                sys_exit(0)
 
 
 def check_device():
@@ -87,13 +163,9 @@ def get_pin(pin_name: RQ_GPIO = None) -> str:
         )
 
 
-def detect_change(pin: RQ_GPIO = None, change: str = None):
-    """Watch for a specific state change on a pin."""
-    pass
-
-
 if __name__ == '__main__':
     import argparse
+    from time import sleep
 
     def _parse_args() -> argparse.Namespace:
         """Get the arguments from the command line."""
@@ -117,6 +189,12 @@ if __name__ == '__main__':
             type=str
         )
         parser.add_argument(
+            '--edge',
+            dest='edge',
+            action='store_true',
+            help='Detect a rising edge'
+        )
+        parser.add_argument(
             '--pin_value',
             dest='pin_value',
             default=None,
@@ -125,6 +203,16 @@ if __name__ == '__main__':
         )
 
         return parser.parse_args()
+
+    def edge_detected(event: gpiod.EdgeEvent) -> None:
+        """Show the edge detection details."""
+        print(
+            f'Rising edge detected on {event.line_offset}'
+            f' at {event.timestamp_ns} ns'
+            f' and sequence {event.line_seqno}'
+        )
+        detector.done = True
+        sys_exit(0)
 
     parsed_args = _parse_args()
 
@@ -139,6 +227,17 @@ if __name__ == '__main__':
             raise Exception(
                 f'{parsed_args.pin_name} is not known'
             )
+
+        if parsed_args.edge:
+            detector = GPIOEdgeDetector(
+                pin,
+                edge_detected,
+                debounce_us=2000
+            )
+            detector.start()
+            while not detector.done:
+                sleep(1.0)
+            detector.stop()
 
         if parsed_args.pin_value:
             print(

--- a/roboquest_core/rq_gpio_utils.py
+++ b/roboquest_core/rq_gpio_utils.py
@@ -16,6 +16,7 @@ from gpiod.line import Bias, Direction, Edge, Value
 
 
 GPIO_DEVICE = '/dev/gpiochip0'
+VERSION = 1
 
 detector = None
 

--- a/roboquest_core/rq_hat.py
+++ b/roboquest_core/rq_hat.py
@@ -2,11 +2,11 @@
 from enum import Enum
 from typing import Callable, Tuple
 
-import RPi.GPIO as GPIO
+from rq_gpio_utils import RQ_GPIO, get_pin, set_pin
 
 import serial
 
-VERSION = 2
+VERSION = 3
 
 READ_EOL = b'\r\n'
 READ_TIMEOUT_SEC = 0.2
@@ -26,16 +26,6 @@ EOL = '\n'
 EOB = '\r'
 DISPLAY_LENGTH = (LINE_LENGTH * LINES) - len(EOB)
 COLUMNS = LINE_LENGTH - len(EOL)
-
-
-class HAT_GPIO_PIN(Enum):
-    """Pins for controlling features of the HAT."""
-
-    COMMS_ENABLE = 22
-    FET_1_ENABLE = 24
-    FET_2_ENABLE = 25
-    CHARGE_BATTERY = 21
-    CHARGER_POWERED = 7
 
 
 class HAT_SCREEN(Enum):
@@ -154,11 +144,9 @@ class RQHAT(object):
     def close(self):
         """Close the serial port.
 
-        Close the serial port and cleanup the GPIO. This method is not intended
-        for internal use.
+        Close the communication with the HAT.
         """
         self._hat.close()
-        GPIO.cleanup()
 
     def _open_hat_serial(self, port: str,
                          data_rate: int,
@@ -229,24 +217,6 @@ class RQHAT(object):
 
         return None
 
-    def cleanup_gpio(self):
-        """Close the GPIO device."""
-        if not self._status_only:
-            if self._controls_state['charger'] == 'ENABLED':
-                GPIO.output(HAT_GPIO_PIN.CHARGE_BATTERY.value, GPIO.HIGH)
-                self._controls_state['charger'] = 'DISABLED'
-
-            if self._controls_state['fet_1'] == 'ENABLED':
-                GPIO.output(HAT_GPIO_PIN.FET_1_ENABLE.value, GPIO.LOW)
-
-            if self._controls_state['fet_2'] == 'ENABLED':
-                GPIO.output(HAT_GPIO_PIN.FET_2_ENABLE.value, GPIO.LOW)
-
-        if self._controls_state['comms'] == 'ENABLED':
-            GPIO.output(HAT_GPIO_PIN.COMMS_ENABLE.value, GPIO.LOW)
-
-        GPIO.cleanup()
-
     def control_comms(self, enable: bool = False):
         """Enable and disable comms.
 
@@ -255,47 +225,38 @@ class RQHAT(object):
         """
         new_state = 'ENABLED' if enable else 'DISABLED'
         if self._controls_state['comms'] != new_state:
-            new_pin_output = GPIO.HIGH if enable else GPIO.LOW
-            GPIO.output(HAT_GPIO_PIN.COMMS_ENABLE.value, new_pin_output)
+            new_pin_output = 'high' if enable else 'low'
+            set_pin(RQ_GPIO['COMMS_ENABLE'], new_pin_output)
             if new_state == 'DISABLED':
                 self._hat.reset_input_buffer()
 
     def _setup_gpio(self):
-        GPIO.setwarnings(False)
-        GPIO.setmode(GPIO.BCM)
-
         if not self._status_only:
             #
-            # Subsequent control of the battery charger should use
-            # charger_control().
+            # Subsequent control of these pins should use the dedicated
+            # method.
             #
-            GPIO.setup(HAT_GPIO_PIN.CHARGE_BATTERY.value, GPIO.OUT)
-            GPIO.output(HAT_GPIO_PIN.CHARGE_BATTERY.value, GPIO.LOW)
+            set_pin(RQ_GPIO['CHARGE_BATTERY'], 'low')
             self._controls_state['charger'] = 'ENABLED'
 
-            GPIO.setup(HAT_GPIO_PIN.FET_1_ENABLE.value, GPIO.OUT)
-            GPIO.output(HAT_GPIO_PIN.FET_1_ENABLE.value, GPIO.LOW)
+            set_pin(RQ_GPIO['FET_1_ENABLE'], 'low')
             self._controls_state['fet_1'] = 'DISABLED'
 
-            GPIO.setup(HAT_GPIO_PIN.FET_2_ENABLE.value, GPIO.OUT)
-            GPIO.output(HAT_GPIO_PIN.FET_2_ENABLE.value, GPIO.LOW)
+            set_pin(RQ_GPIO['FET_2_ENABLE'], 'low')
             self._controls_state['fet_2'] = 'DISABLED'
-
-            GPIO.setup(HAT_GPIO_PIN.CHARGER_POWERED.value, GPIO.IN)
 
         #
         # Subsequent control of the communications channel should use
         # control_comms().
         #
         try:
-            GPIO.setup(HAT_GPIO_PIN.COMMS_ENABLE.value, GPIO.OUT)
-            GPIO.output(HAT_GPIO_PIN.COMMS_ENABLE.value, GPIO.LOW)
+            set_pin(RQ_GPIO['COMMS_ENABLE'], 'low')
             self._controls_state['comms'] = 'DISABLED'
 
         except Exception as e:
             raise Exception(
                 'Exception configuring COMMS ENABLE pin'
-                f' GPIO.VERSION {GPIO.VERSION}: {e}'
+                f' {e}'
             )
 
     def charger_state(self) -> Tuple[bool, bool]:
@@ -308,8 +269,8 @@ class RQHAT(object):
         if self._status_only:
             raise Exception('Status only')
 
-        power_pin = GPIO.input(HAT_GPIO_PIN.CHARGER_POWERED.value)
-        charger_has_power = True if power_pin == GPIO.HIGH else False
+        power_pin = get_pin(RQ_GPIO['CHARGER_POWERED'])
+        charger_has_power = True if power_pin == 'high' else False
 
         if not charger_has_power:
             #
@@ -333,8 +294,8 @@ class RQHAT(object):
             #
             # This pin is non-standard. Setting it LOW enables the charger.
             #
-            new_pin_output = GPIO.LOW if on else GPIO.HIGH
-            GPIO.output(HAT_GPIO_PIN.CHARGE_BATTERY.value, new_pin_output)
+            new_pin_output = 'low' if on else 'high'
+            set_pin(RQ_GPIO['CHARGE_BATTERY'], new_pin_output)
             self._controls_state['charger'] = new_state
 
     def fet1_control(self, on: bool = False) -> None:
@@ -344,8 +305,8 @@ class RQHAT(object):
 
         new_state = 'ENABLED' if on else 'DISABLED'
         if self._controls_state['fet_1'] != new_state:
-            new_pin_output = GPIO.HIGH if on else GPIO.LOW
-            GPIO.output(HAT_GPIO_PIN.FET_1_ENABLE.value, new_pin_output)
+            new_pin_output = 'high' if on else 'low'
+            set_pin(RQ_GPIO['FET_1_ENABLE'], new_pin_output)
             self._controls_state['fet_1'] = new_state
 
     def fet2_control(self, on: bool = False) -> None:
@@ -355,8 +316,8 @@ class RQHAT(object):
 
         new_state = 'ENABLED' if on else 'DISABLED'
         if self._controls_state['fet_2'] != new_state:
-            new_pin_output = GPIO.HIGH if on else GPIO.LOW
-            GPIO.output(HAT_GPIO_PIN.FET_2_ENABLE.value, new_pin_output)
+            new_pin_output = 'high' if on else 'low'
+            set_pin(RQ_GPIO['FET_2_ENABLE'], new_pin_output)
             self._controls_state['fet_2'] = new_state
 
     def status_msg(self, message: str) -> None:

--- a/roboquest_core/rq_hat.py
+++ b/roboquest_core/rq_hat.py
@@ -116,10 +116,22 @@ class RQHAT(object):
                  parity: str,
                  stop_bits: int,
                  read_timeout_sec: float,
-                 serial_errors_cb: Callable = None):
+                 serial_errors_cb: Callable = None,
+                 status_only: bool = False):
         """Initialize the HAT."""
         self._serial_errors_cb = serial_errors_cb
 
+        #
+        # self._status_only indicates the caller of __init__() will use
+        # only:
+        #  control_comms()
+        #  close()
+        #  status_msg()
+        #  show_status_msgs()
+        # Because of that limited use, most of the GPIO pin configuration
+        # is skipped.
+        #
+        self._status_only = status_only
         self._hat = None
         self._controls_state = {
             'charger': 'UNKNOWN',
@@ -172,8 +184,10 @@ class RQHAT(object):
             self._hat.reset_input_buffer()
             self._hat.reset_output_buffer()
 
-        except serial.SerialException:
-            self._hat = None
+        except serial.SerialException as e:
+            raise Exception(
+                f'Failed to setup {port}: {e}'
+            )
 
     def write_sentence(self, sentence: str) -> None:
         """Encode from ASCII and then write the sentence."""
@@ -217,15 +231,16 @@ class RQHAT(object):
 
     def cleanup_gpio(self):
         """Close the GPIO device."""
-        if self._controls_state['charger'] == 'ENABLED':
-            GPIO.output(HAT_GPIO_PIN.CHARGE_BATTERY.value, GPIO.HIGH)
-            self._controls_state['charger'] = 'DISABLED'
+        if not self._status_only:
+            if self._controls_state['charger'] == 'ENABLED':
+                GPIO.output(HAT_GPIO_PIN.CHARGE_BATTERY.value, GPIO.HIGH)
+                self._controls_state['charger'] = 'DISABLED'
 
-        if self._controls_state['fet_1'] == 'ENABLED':
-            GPIO.output(HAT_GPIO_PIN.FET_1_ENABLE.value, GPIO.LOW)
+            if self._controls_state['fet_1'] == 'ENABLED':
+                GPIO.output(HAT_GPIO_PIN.FET_1_ENABLE.value, GPIO.LOW)
 
-        if self._controls_state['fet_2'] == 'ENABLED':
-            GPIO.output(HAT_GPIO_PIN.FET_2_ENABLE.value, GPIO.LOW)
+            if self._controls_state['fet_2'] == 'ENABLED':
+                GPIO.output(HAT_GPIO_PIN.FET_2_ENABLE.value, GPIO.LOW)
 
         if self._controls_state['comms'] == 'ENABLED':
             GPIO.output(HAT_GPIO_PIN.COMMS_ENABLE.value, GPIO.LOW)
@@ -249,31 +264,39 @@ class RQHAT(object):
         GPIO.setwarnings(False)
         GPIO.setmode(GPIO.BCM)
 
-        #
-        # Subsequent control of the battery charger should use
-        # charger_control().
-        #
-        GPIO.setup(HAT_GPIO_PIN.CHARGE_BATTERY.value, GPIO.OUT)
-        GPIO.output(HAT_GPIO_PIN.CHARGE_BATTERY.value, GPIO.LOW)
-        self._controls_state['charger'] = 'ENABLED'
+        if not self._status_only:
+            #
+            # Subsequent control of the battery charger should use
+            # charger_control().
+            #
+            GPIO.setup(HAT_GPIO_PIN.CHARGE_BATTERY.value, GPIO.OUT)
+            GPIO.output(HAT_GPIO_PIN.CHARGE_BATTERY.value, GPIO.LOW)
+            self._controls_state['charger'] = 'ENABLED'
 
-        GPIO.setup(HAT_GPIO_PIN.FET_1_ENABLE.value, GPIO.OUT)
-        GPIO.output(HAT_GPIO_PIN.FET_1_ENABLE.value, GPIO.LOW)
-        self._controls_state['fet_1'] = 'DISABLED'
+            GPIO.setup(HAT_GPIO_PIN.FET_1_ENABLE.value, GPIO.OUT)
+            GPIO.output(HAT_GPIO_PIN.FET_1_ENABLE.value, GPIO.LOW)
+            self._controls_state['fet_1'] = 'DISABLED'
 
-        GPIO.setup(HAT_GPIO_PIN.FET_2_ENABLE.value, GPIO.OUT)
-        GPIO.output(HAT_GPIO_PIN.FET_2_ENABLE.value, GPIO.LOW)
-        self._controls_state['fet_2'] = 'DISABLED'
+            GPIO.setup(HAT_GPIO_PIN.FET_2_ENABLE.value, GPIO.OUT)
+            GPIO.output(HAT_GPIO_PIN.FET_2_ENABLE.value, GPIO.LOW)
+            self._controls_state['fet_2'] = 'DISABLED'
+
+            GPIO.setup(HAT_GPIO_PIN.CHARGER_POWERED.value, GPIO.IN)
 
         #
         # Subsequent control of the communications channel should use
         # control_comms().
         #
-        GPIO.setup(HAT_GPIO_PIN.COMMS_ENABLE.value, GPIO.OUT)
-        GPIO.output(HAT_GPIO_PIN.COMMS_ENABLE.value, GPIO.LOW)
-        self._controls_state['comms'] = 'DISABLED'
+        try:
+            GPIO.setup(HAT_GPIO_PIN.COMMS_ENABLE.value, GPIO.OUT)
+            GPIO.output(HAT_GPIO_PIN.COMMS_ENABLE.value, GPIO.LOW)
+            self._controls_state['comms'] = 'DISABLED'
 
-        GPIO.setup(HAT_GPIO_PIN.CHARGER_POWERED.value, GPIO.IN)
+        except Exception as e:
+            raise Exception(
+                'Exception configuring COMMS ENABLE pin'
+                f' GPIO.VERSION {GPIO.VERSION}: {e}'
+            )
 
     def charger_state(self) -> Tuple[bool, bool]:
         """Return charger state.
@@ -282,6 +305,9 @@ class RQHAT(object):
             - the battery is being charged
             - the charger has power
         """
+        if self._status_only:
+            raise Exception('Status only')
+
         power_pin = GPIO.input(HAT_GPIO_PIN.CHARGER_POWERED.value)
         charger_has_power = True if power_pin == GPIO.HIGH else False
 
@@ -299,6 +325,9 @@ class RQHAT(object):
 
     def charger_control(self, on: bool = False) -> None:
         """Control the charger."""
+        if self._status_only:
+            raise Exception('Status only')
+
         new_state = 'ENABLED' if on else 'DISABLED'
         if self._controls_state['charger'] != new_state:
             #
@@ -310,6 +339,9 @@ class RQHAT(object):
 
     def fet1_control(self, on: bool = False) -> None:
         """Control FET 1."""
+        if self._status_only:
+            raise Exception('Status only')
+
         new_state = 'ENABLED' if on else 'DISABLED'
         if self._controls_state['fet_1'] != new_state:
             new_pin_output = GPIO.HIGH if on else GPIO.LOW
@@ -318,6 +350,9 @@ class RQHAT(object):
 
     def fet2_control(self, on: bool = False) -> None:
         """Control FET 2."""
+        if self._status_only:
+            raise Exception('Status only')
+
         new_state = 'ENABLED' if on else 'DISABLED'
         if self._controls_state['fet_2'] != new_state:
             new_pin_output = GPIO.HIGH if on else GPIO.LOW

--- a/scripts/access_point.bash
+++ b/scripts/access_point.bash
@@ -1,16 +1,20 @@
 #!/usr/bin/env bash
 #
-# Bill Mania, 24 Jan 2022
-#
 # Executed at boot to ensure there is an Access Point setup to
 # allow wireless access to the robot. If the AP connection
 # doesn't exist, it is created. If it does exist, its SSID
 # definition is updated to match the current hardware.
 #
+# In order to not require hosting a DHCP server on the robot,
+# an address is statically assigned to the robot. The requirements
+# for the host computer are in
+# https://github.com/billmania/roboquest_core/wiki/Robot-WiFi-Access-Point
+#
 
 NM_CONN_NAME="roboAP"
 AP_SSID_BASE="roboAP"
 AP_PSK="roboquest"
+AP_IP="192.168.193.1/24"
 
 #
 # In order to create a unique Access Point number, append
@@ -39,13 +43,12 @@ then
         conn modify $NM_CONN_NAME \
         802-11-wireless.mode ap \
         802-11-wireless.band bg \
-        ipv4.method shared
-    nmcli -c no \
-        conn modify $NM_CONN_NAME \
-        wifi-sec.key-mgmt wpa-psk
-    nmcli -c no \
-        conn modify $NM_CONN_NAME \
-        wifi-sec.psk $AP_PSK
+        802-11-wireless.channel 6 \
+        802-11-wireless-security.key-mgmt wpa-psk \
+        802-11-wireless-security.psk "$AP_PSK" \
+        ipv4.addresses "$AP_IP" \
+        ipv4.method manual \
+        ipv6.method disabled
 else
     logger -p user.notice  "Access Point ${NM_CONN_NAME} exists"
     ssid=$(nmcli -c no -t --fields 802-11-wireless.ssid conn show ${NM_CONN_NAME} \

--- a/scripts/updater.py
+++ b/scripts/updater.py
@@ -27,19 +27,18 @@ from socket import AF_INET, SOCK_DGRAM, socket
 from sys import exit
 from time import sleep
 
-import RPi.GPIO as GPIO
-
 import docker
 
 from requests import get
 from requests.exceptions import ConnectionError as GetConnectionError
 
+from rq_gpio_utils import GPIOEdgeDetector, RQ_GPIO
+
 from rq_hat import RQHAT
 
 # VERSION = '22rc1'
 VERSION = '21'
-HAT_SERIAL = '/dev/ttyAMA1'
-SHUTDOWN_PIN = 27
+HAT_SERIAL = '/dev/ttyAMA3'
 SERIAL_NUMBER_FILE = '/sys/firmware/devicetree/base/serial-number'
 RQ_CORE_PERSIST = (
     '/usr/src/ros2ws/install/roboquest_core/share/roboquest_core/persist'
@@ -88,7 +87,7 @@ CONTAINERS = {
         'devices': ['/dev/gpiomem:/dev/gpiomem:rwm',
                     '/dev/i2c-1:/dev/i2c-1:rwm',
                     '/dev/i2c-6:/dev/i2c-6:rwm',
-                    HAT_SERIAL+':'+HAT_SERIAL+':rwm'],
+                    HAT_SERIAL+':/dev/ttyAMA1:rwm'],
         'volumes': ['/dev/shm:/dev/shm',
                     '/var/run/dbus:/var/run/dbus',
                     '/run/udev:/run/udev:ro',
@@ -117,10 +116,6 @@ class RQUpdate(object):
             format='%(asctime)s %(levelname)s %(message)s',
             level=logging.INFO)
         logging.info(f'updater.py version {VERSION} started')
-
-        signal(SIGHUP, self.shutdown)
-        signal(SIGINT, self.shutdown)
-        signal(SIGTERM, self.shutdown)
 
         #
         # A safety flag, to ensure the HAT serial port isn't touched
@@ -288,12 +283,16 @@ class RQUpdate(object):
         Setup the callback to call when the shutdown hardware
         signal is detected.
         """
-        GPIO.setmode(GPIO.BCM)
-        GPIO.setup(SHUTDOWN_PIN, GPIO.IN)
-        GPIO.add_event_detect(
-            SHUTDOWN_PIN,
-            GPIO.RISING
+        self._shutdown_detector = GPIOEdgeDetector(
+            RQ_GPIO['SHUTDOWN'],
+            self.shutdown,
+            debounce_us=1000
         )
+        self._shutdown_detector.start()
+
+        signal(SIGHUP, self.shutdown)
+        signal(SIGINT, self.shutdown)
+        signal(SIGTERM, self.shutdown)
 
     def _setup_docker(self):
         """Create the docker client."""
@@ -1043,13 +1042,6 @@ class RQUpdate(object):
         self._status_msg('starting RoboQuest')
         self._setup_shutdown()
         while True:
-            try:
-                if GPIO.event_detected(SHUTDOWN_PIN):
-                    self._shutdown_cb('BUTTON')
-
-            except RuntimeError:
-                self._setup_shutdown()
-
             self._check_configs(restore=False)
             self._check_running_containers()
 
@@ -1058,6 +1050,11 @@ class RQUpdate(object):
                 self._process_message(message)
             else:
                 sleep(LOOP_PERIOD_S)
+
+    def _gpio_shutdown(self, event) -> None:
+        """Handle the GPIO shutdown signal."""
+        self._shutdown_detector.done = True
+        self._shutdown_cb(arg='BUTTON')
 
     def _shutdown_cb(self, arg='UNKNOWN'):
         """
@@ -1068,8 +1065,9 @@ class RQUpdate(object):
         """
         if arg == 'SHUTDOWN':
             logging.warning('Shutdown triggered by UI')
-        elif type(arg) is int:
+        elif arg == 'BUTTON':
             logging.warning('Shutdown button pressed')
+            self._shutdown_detector.stop()
         else:
             logging.warning(f'Shutdown by {arg}')
 

--- a/scripts/updater.py
+++ b/scripts/updater.py
@@ -36,6 +36,7 @@ from requests.exceptions import ConnectionError as GetConnectionError
 
 from rq_hat import RQHAT
 
+# VERSION = '22rc1'
 VERSION = '21'
 HAT_SERIAL = '/dev/ttyAMA1'
 SHUTDOWN_PIN = 27
@@ -486,14 +487,26 @@ class RQUpdate(object):
         to the HAT must be destroyed before the containers are started,
         to prevent conflict with the containers.
         """
-        self._hat = RQHAT(
-            HAT_SERIAL,
-            38400,
-            7,
-            'N',
-            1,
-            1.0)
-        self._hat.control_comms(enable=False)
+        try:
+            self._hat = RQHAT(
+                HAT_SERIAL,
+                38400,
+                7,
+                'N',
+                1,
+                1.0,
+                True
+            )
+
+        except Exception as e:
+            logging.warning(
+                'Exception during HAT setup'
+                f': {e}'
+            )
+            self._hat = None
+
+        if self._hat:
+            self._hat.control_comms(enable=False)
 
     def _close_hat(self):
         """Close the HAT connection.
@@ -501,7 +514,8 @@ class RQUpdate(object):
         Completely reset and shutdown the serial port and the GPIO
         sub-system.
         """
-        self._hat.close()
+        if self._hat:
+            self._hat.close()
 
     def _status_msg(self, msg: str = None) -> None:
         """
@@ -531,12 +545,13 @@ class RQUpdate(object):
         # means to persist previous updater.py status lines and to
         # refresh the display without adding another line.
         #
-        self._hat._status_lines = self._status_messages
-        if msg is not None:
-            self._hat.status_msg(msg)
-            self._status_messages = self._hat._status_lines
-        else:
-            self._hat.show_status_msgs()
+        if self._hat:
+            self._hat._status_lines = self._status_messages
+            if msg is not None:
+                self._hat.status_msg(msg)
+                self._status_messages = self._hat._status_lines
+            else:
+                self._hat.show_status_msgs()
 
     def stop_containers(self):
         """Kill any running containers."""


### PR DESCRIPTION
rq_hat.py and updater.py are now using modern GPIO control. The new module rq_gpio_utils.py includes testing utilities. The OS utility gpioinfo is useful to observe the state of the GPIO sub-system.

This requires [rq_ui PR 170](https://github.com/billmania/roboquest_ui/pull/170).

This version appears to have a bug in the handling of the GPIO shutdown signal by updater.py. See rq_core Issue X.